### PR TITLE
fix!: AWSIM directory structure

### DIFF
--- a/aichallenge/run_evaluation.bash
+++ b/aichallenge/run_evaluation.bash
@@ -1,4 +1,5 @@
 #!/bin/bash
+AWSIM_DIRECTORY=/aichallenge/simulator/AWSIM
 
 # Move working directory
 OUTPUT_DIRECTORY=$(date +%Y%m%d-%H%M%S)
@@ -13,7 +14,7 @@ sudo sysctl -w net.core.rmem_max=2147483647 >/dev/null
 
 # Start AWSIM
 echo "Start AWSIM"
-/aichallenge/simulator/AWSIM.x86_64 >/dev/null &
+$AWSIM_DIRECTORY/AWSIM.x86_64 >/dev/null &
 PID_AWSIM=$!
 sleep 20
 

--- a/aichallenge/run_simulator.bash
+++ b/aichallenge/run_simulator.bash
@@ -1,6 +1,7 @@
 #!/bin/bash
+AWSIM_DIRECTORY=/aichallenge/simulator/AWSIM
 
 # shellcheck disable=SC1091
 source /aichallenge/workspace/install/setup.bash
 sudo ip link set multicast on lo
-/aichallenge/simulator/AWSIM.x86_64
+$AWSIM_DIRECTORY/AWSIM.x86_64


### PR DESCRIPTION
現状の運用としてはsimulatorの配下に必要な以下のファイルを置いて実行する方式になっています。
- AWSIM.x86_64
- AWSIM_Data
- UnityPlayer.so
[参考]
https://github.com/AutomotiveAIChallenge/aichallenge-2024/tree/main/aichallenge/simulator
https://github.com/AutomotiveAIChallenge/aichallenge-2024/blob/main/aichallenge/run_simulator.bash

下記の理由により、必要なファイルだけを展開するのではなく、フォルダごとに実行ファイルをもっていて、実行フォルダを run_simulator.bashで実行するほうが運用しやすいう結論になりました。

- Unityでシーンをbuildして実行ファイルにするときはフォルダが作成されること
- 練習用、本番用などの異なるAWSIMを実行したいニーズがでてくること

eval gpu / dev gpuで動作確認済
`RUN git clone --depth 1 https://github.com/AutomotiveAIChallenge/aichallenge-2024 -b fix/AWSIM_directory /ws/repository`

![image](https://github.com/AutomotiveAIChallenge/aichallenge-2024/assets/65527974/efc6d33f-3343-42b3-aa06-64d78d88c113)
