### PR TITLE
feat: add temporary marker for pit stop

### DIFF
--- a/aichallenge/workspace/src/aichallenge_system/aichallenge_system_launch/config/autoware.rviz
+++ b/aichallenge/workspace/src/aichallenge_system/aichallenge_system_launch/config/autoware.rviz
@@ -1757,6 +1757,18 @@ Visualization Manager:
         Reliability Policy: Reliable
         Value: /aichallenge/objects_marker
       Value: true
+    - Class: rviz_default_plugins/MarkerArray
+      Enabled: true
+      Name: MarkerArray
+      Namespaces:
+        "": true
+      Topic:
+        Depth: 1
+        Durability Policy: Transient Local
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /aichallenge/pitstop/area_marker
+      Value: true
   Enabled: true
   Global Options:
     Background Color: 10; 10; 10

--- a/aichallenge/workspace/src/aichallenge_system/aichallenge_system_launch/script/object_marker.py
+++ b/aichallenge/workspace/src/aichallenge_system/aichallenge_system_launch/script/object_marker.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 import rclpy
 import rclpy.node
+import rclpy.qos
+import rclpy.executors
 from std_msgs.msg import Float64MultiArray
 from visualization_msgs.msg import MarkerArray
 from visualization_msgs.msg import Marker
@@ -37,12 +39,50 @@ class ObjectMarkerNode(rclpy.node.Node):
         marker.color.a = 1.0
         return marker
 
+class PitStopMarkerNode(rclpy.node.Node):
+
+    def __init__(self):
+        super().__init__("pitstop_marker")
+        qos = rclpy.qos.QoSProfile(depth=1, reliability=rclpy.qos.QoSReliabilityPolicy.RELIABLE, durability=rclpy.qos.QoSDurabilityPolicy.TRANSIENT_LOCAL)
+        self.pub = self.create_publisher(MarkerArray, "/aichallenge/pitstop/area_marker", qos)
+        self.callback(None)
+
+    def callback(self, msg):
+        markers = MarkerArray()
+        markers.markers = [self.create_marker()]
+        self.pub.publish(markers)
+
+    def create_marker(self):
+        marker = Marker()
+        marker.header.frame_id = "map"
+        marker.header.stamp = self.get_clock().now().to_msg()
+        marker.id = 0
+        marker.type = Marker.CUBE
+        marker.action = Marker.ADD
+        marker.pose.position.x = 89626.3671875
+        marker.pose.position.y = 43134.921875
+        marker.pose.position.z = -29.700000762939453
+        marker.pose.orientation.x = 0.0
+        marker.pose.orientation.y = 0.0
+        marker.pose.orientation.z = -0.8788172006607056
+        marker.pose.orientation.w = -0.47715866565704346
+        marker.scale.x = 4.0
+        marker.scale.y = 2.0
+        marker.scale.z = 0.1
+        marker.color.r = 0.0
+        marker.color.g = 1.0
+        marker.color.b = 0.0
+        marker.color.a = 1.0
+        return marker
 
 def main(args=None):
     rclpy.init(args=args)
+    executor = rclpy.executors.SingleThreadedExecutor()
+    executor.add_node(ObjectMarkerNode())
+    executor.add_node(PitStopMarkerNode())
+    executor.spin()
     rclpy.spin(ObjectMarkerNode())
     rclpy.shutdown()
-
 
 if __name__ == "__main__":
     main()

--- a/aichallenge/workspace/src/aichallenge_system/aichallenge_system_launch/script/object_marker.py
+++ b/aichallenge/workspace/src/aichallenge_system/aichallenge_system_launch/script/object_marker.py
@@ -71,7 +71,7 @@ class PitStopMarkerNode(rclpy.node.Node):
         marker.scale.z = 0.1
         marker.color.r = 0.0
         marker.color.g = 1.0
-        marker.color.b = 0.0
+        marker.color.b = 1.0
         marker.color.a = 1.0
         return marker
 


### PR DESCRIPTION
https://github.com/AutomotiveAIChallenge/aichallenge-2024/issues/22
描画なしのAWSIMではピットストップエリアの位置を特定できないため、応急処置としてAWSIMと同じ場所にマーカーを表示するように変更しました。正式な対応としてAWSIMからエリアの座標を出力するように修正する予定です。