### PR TITLE
fix: correct localization

### DIFF
--- a/aichallenge/pkill_all.sh
+++ b/aichallenge/pkill_all.sh
@@ -1,0 +1,17 @@
+pkill -9 robot_state_pub
+pkill -9 vehicle_velocit
+pkill -9 imu_gnss_poser_
+pkill -9 twist2accel
+pkill -9 empty_objects_p
+pkill -9 goal_pose_visua
+pkill -9 path_to_traject
+pkill -9 goal_pose_sette
+pkill -9 ros2
+pkill -9 python3
+pkill -9 rviz2
+pkill -9 ekf_localizer
+pkill -9 mission_planner
+pkill -9 component_conta
+pkill -9 simple_pure_pur
+pkill -9 initial_pose_ad
+pkill -9 routing_adaptor

--- a/aichallenge/workspace/src/aichallenge_submit/aichallenge_submit_launch/launch/reference.launch.xml
+++ b/aichallenge/workspace/src/aichallenge_submit/aichallenge_submit_launch/launch/reference.launch.xml
@@ -41,6 +41,12 @@
       <arg name="input_vehicle_velocity_topic" value="/vehicle/status/velocity_status"/>
       <arg name="output_twist_with_covariance" value="/sensing/vehicle_velocity_converter/twist_with_covariance"/>
     </include>
+    <arg name="imu_corrector_param_file" default="$(find-pkg-share aichallenge_submit_launch)/config/imu_corrector.param.yaml"/>
+      <include file="$(find-pkg-share imu_corrector)/launch/imu_corrector.launch.xml">
+        <arg name="input_topic" value="imu_raw"/>
+        <arg name="output_topic" value="imu_data"/>
+        <arg name="param_file" value="$(var imu_corrector_param_file)"/>
+      </include>
   </group>
 
   <!-- Localization -->
@@ -48,7 +54,7 @@
     <push-ros-namespace namespace="localization"/>
     <include file="$(find-pkg-share gyro_odometer)/launch/gyro_odometer.launch.xml">
       <arg name="input_vehicle_twist_with_covariance_topic" value="/sensing/vehicle_velocity_converter/twist_with_covariance"/>
-      <arg name="input_imu_topic" value="/sensing/imu/imu_raw"/>
+      <arg name="input_imu_topic" value="/sensing/imu/imu_data"/>
       <arg name="output_twist_with_covariance_topic" value="/localization/twist_estimator/twist_with_covariance"/>
       <arg name="output_twist_with_covariance_raw_topic" value="/localization/twist_estimator/twist_with_covariance_raw"/>
     </include>
@@ -58,7 +64,7 @@
     <include file="$(find-pkg-share ekf_localizer)/launch/ekf_localizer.launch.xml">
       <arg name="enable_yaw_bias_estimation" value="false"/>
       <arg name="tf_rate" value="50.0"/>
-      <arg name="twist_smoothing_steps" value="3"/>
+      <arg name="twist_smoothing_steps" value="1"/>
       <arg name="input_initial_pose_name" value="/localization/initial_pose3d"/>
       <arg name="input_pose_with_cov_name" value="/localization/imu_gnss_poser/pose_with_covariance"/>
       <arg name="input_twist_with_cov_name" value="/localization/twist_estimator/twist_with_covariance"/>
@@ -196,10 +202,10 @@
 
   <node pkg="simple_pure_pursuit" exec="simple_pure_pursuit" name="simple_pure_pursuit_node" output="screen">
     <param name="use_external_target_vel" value="true"/>
-    <param name="external_target_vel" value="3.0"/>
+    <param name="external_target_vel" value="8.0"/>
     <param name="lookahead_gain" value="0.4"/>
     <param name="lookahead_min_distance" value="5.0"/>
-    <param name="speed_proportional_gain" value="0.1"/>
+    <param name="speed_proportional_gain" value="1.0"/>
 
     <remap from="input/kinematics" to="/localization/kinematic_state"/>
     <remap from="input/trajectory" to="/planning/scenario_planning/trajectory"/>

--- a/aichallenge/workspace/src/aichallenge_submit/aichallenge_submit_launch/launch/reference.launch.xml
+++ b/aichallenge/workspace/src/aichallenge_submit/aichallenge_submit_launch/launch/reference.launch.xml
@@ -41,12 +41,15 @@
       <arg name="input_vehicle_velocity_topic" value="/vehicle/status/velocity_status"/>
       <arg name="output_twist_with_covariance" value="/sensing/vehicle_velocity_converter/twist_with_covariance"/>
     </include>
-    <arg name="imu_corrector_param_file" default="$(find-pkg-share aichallenge_submit_launch)/config/imu_corrector.param.yaml"/>
-      <include file="$(find-pkg-share imu_corrector)/launch/imu_corrector.launch.xml">
-        <arg name="input_topic" value="imu_raw"/>
-        <arg name="output_topic" value="imu_data"/>
-        <arg name="param_file" value="$(var imu_corrector_param_file)"/>
-      </include>
+    <group>
+      <push-ros-namespace namespace="imu"/>
+      <arg name="imu_corrector_param_file" default="$(find-pkg-share aichallenge_submit_launch)/config/imu_corrector.param.yaml"/>
+        <include file="$(find-pkg-share imu_corrector)/launch/imu_corrector.launch.xml">
+          <arg name="input_topic" value="imu_raw"/>
+          <arg name="output_topic" value="imu_data"/>
+          <arg name="param_file" value="$(var imu_corrector_param_file)"/>
+        </include>
+    </group>
   </group>
 
   <!-- Localization -->

--- a/aichallenge/workspace/src/aichallenge_submit/aichallenge_submit_launch/launch/reference.launch.xml
+++ b/aichallenge/workspace/src/aichallenge_submit/aichallenge_submit_launch/launch/reference.launch.xml
@@ -206,8 +206,8 @@
   <node pkg="simple_pure_pursuit" exec="simple_pure_pursuit" name="simple_pure_pursuit_node" output="screen">
     <param name="use_external_target_vel" value="true"/>
     <param name="external_target_vel" value="8.0"/>
-    <param name="lookahead_gain" value="0.4"/>
-    <param name="lookahead_min_distance" value="5.0"/>
+    <param name="lookahead_gain" value="0.3"/>
+    <param name="lookahead_min_distance" value="4.0"/>
     <param name="speed_proportional_gain" value="1.0"/>
 
     <remap from="input/kinematics" to="/localization/kinematic_state"/>

--- a/aichallenge/workspace/src/aichallenge_submit/aichallenge_submit_launch/launch/reference.launch.xml
+++ b/aichallenge/workspace/src/aichallenge_submit/aichallenge_submit_launch/launch/reference.launch.xml
@@ -58,8 +58,8 @@
     <include file="$(find-pkg-share ekf_localizer)/launch/ekf_localizer.launch.xml">
       <arg name="enable_yaw_bias_estimation" value="false"/>
       <arg name="tf_rate" value="50.0"/>
-      <arg name="twist_smoothing_steps" value="2"/>
-      <arg name="input_initial_pose_name" value="/localization/imu_gnss_poser/pose_with_covariance"/>
+      <arg name="twist_smoothing_steps" value="3"/>
+      <arg name="input_initial_pose_name" value="/localization/initial_pose3d"/>
       <arg name="input_pose_with_cov_name" value="/localization/imu_gnss_poser/pose_with_covariance"/>
       <arg name="input_twist_with_cov_name" value="/localization/twist_estimator/twist_with_covariance"/>
       <arg name="output_odom_name" value="kinematic_state"/>
@@ -196,10 +196,10 @@
 
   <node pkg="simple_pure_pursuit" exec="simple_pure_pursuit" name="simple_pure_pursuit_node" output="screen">
     <param name="use_external_target_vel" value="true"/>
-    <param name="external_target_vel" value="8.0"/>
+    <param name="external_target_vel" value="3.0"/>
     <param name="lookahead_gain" value="0.4"/>
     <param name="lookahead_min_distance" value="5.0"/>
-    <param name="speed_proportional_gain" value="1.0"/>
+    <param name="speed_proportional_gain" value="0.1"/>
 
     <remap from="input/kinematics" to="/localization/kinematic_state"/>
     <remap from="input/trajectory" to="/planning/scenario_planning/trajectory"/>

--- a/aichallenge/workspace/src/aichallenge_submit/aichallenge_submit_launch/map/lanelet2_map.osm
+++ b/aichallenge/workspace/src/aichallenge_submit/aichallenge_submit_launch/map/lanelet2_map.osm
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <osm generator="VMB">
-  <MetaInfo format_version="1" map_version="12"/>
+  <MetaInfo format_version="1" map_version="13"/>
   <node id="8" lat="35.62581952967" lon="139.78142932797">
     <tag k="mgrs_code" v="54SUE896431"/>
     <tag k="local_x" v="89653.9564"/>
@@ -4801,58 +4801,46 @@
     <tag k="local_y" v="43165.9976"/>
     <tag k="ele" v="43.0492"/>
   </node>
-  <node id="2173" lat="35.6261493375" lon="139.78153940969">
+  <node id="2173" lat="35.62614929283" lon="139.78153499329">
     <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89664.3784"/>
+    <tag k="local_x" v="89663.9784"/>
     <tag k="local_y" v="43167.6896"/>
     <tag k="ele" v="43.1002"/>
   </node>
-  <node id="2174" lat="35.62616012591" lon="139.78155073368">
+  <node id="2174" lat="35.6261672928" lon="139.78154620786">
     <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89665.4187"/>
-    <tag k="local_y" v="43168.8735"/>
+    <tag k="local_x" v="89665.0187"/>
+    <tag k="local_y" v="43169.6735"/>
     <tag k="ele" v="43.1087"/>
   </node>
-  <node id="2175" lat="35.62617036892" lon="139.7815669667">
+  <node id="2175" lat="35.62617753581" lon="139.78156244087">
     <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89666.9028"/>
-    <tag k="local_y" v="43169.9914"/>
+    <tag k="local_x" v="89666.5028"/>
+    <tag k="local_y" v="43170.7914"/>
     <tag k="ele" v="43.1189"/>
   </node>
-  <node id="2176" lat="35.6261758316" lon="139.78158577232">
+  <node id="2176" lat="35.6261829985" lon="139.78158124649">
     <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89668.6133"/>
-    <tag k="local_y" v="43170.5762"/>
+    <tag k="local_x" v="89668.2133"/>
+    <tag k="local_y" v="43171.3762"/>
     <tag k="ele" v="43.1282"/>
   </node>
-  <node id="2181" lat="35.62617789666" lon="139.78160096774">
+  <node id="2181" lat="35.62618510823" lon="139.78160085831">
     <tag k="mgrs_code" v="54SUE896431"/>
     <tag k="local_x" v="89669.9922"/>
-    <tag k="local_y" v="43170.7882"/>
+    <tag k="local_y" v="43171.5882"/>
     <tag k="ele" v="43.1044"/>
   </node>
-  <node id="2182" lat="35.6261763004" lon="139.78161001494">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89670.8093"/>
-    <tag k="local_y" v="43170.601"/>
-    <tag k="ele" v="43.0985"/>
-  </node>
-  <node id="2183" lat="35.62617437531" lon="139.78161721416">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89671.4586"/>
-    <tag k="local_y" v="43170.3794"/>
-    <tag k="ele" v="43.0831"/>
-  </node>
-  <node id="2184" lat="35.62617273654" lon="139.78162517762">
+  <node id="2184" lat="35.62617994811" lon="139.78162506819">
     <tag k="mgrs_code" v="54SUE896431"/>
     <tag k="local_x" v="89672.1775"/>
-    <tag k="local_y" v="43170.1887"/>
+    <tag k="local_y" v="43170.9887"/>
     <tag k="ele" v="43.0629"/>
   </node>
-  <node id="2185" lat="35.62616956055" lon="139.78163305065">
+  <node id="2185" lat="35.62617227605" lon="139.78163411372">
     <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89672.8861"/>
-    <tag k="local_y" v="43169.8276"/>
+    <tag k="local_x" v="89672.9861"/>
+    <tag k="local_y" v="43170.1276"/>
     <tag k="ele" v="43.0517"/>
   </node>
   <node id="2186" lat="35.62616508095" lon="139.78164084298">
@@ -5962,8 +5950,6 @@
     <nd ref="2175"/>
     <nd ref="2176"/>
     <nd ref="2181"/>
-    <nd ref="2182"/>
-    <nd ref="2183"/>
     <nd ref="2184"/>
     <nd ref="2185"/>
     <nd ref="2186"/>

--- a/aichallenge/workspace/src/aichallenge_submit/gyro_odometer/CMakeLists.txt
+++ b/aichallenge/workspace/src/aichallenge_submit/gyro_odometer/CMakeLists.txt
@@ -1,0 +1,35 @@
+cmake_minimum_required(VERSION 3.14)
+project(gyro_odometer)
+
+find_package(autoware_cmake REQUIRED)
+autoware_package()
+
+ament_auto_add_executable(${PROJECT_NAME}
+  src/gyro_odometer_node.cpp
+  src/gyro_odometer_core.cpp
+)
+
+target_link_libraries(${PROJECT_NAME} fmt)
+
+ament_auto_add_library(gyro_odometer_node SHARED
+  src/gyro_odometer_core.cpp
+)
+
+if(BUILD_TESTING)
+  ament_add_ros_isolated_gtest(test_gyro_odometer
+    test/test_main.cpp
+    test/test_gyro_odometer_pubsub.cpp
+    test/test_gyro_odometer_helper.cpp
+  )
+  ament_target_dependencies(test_gyro_odometer
+    rclcpp
+  )
+  target_link_libraries(test_gyro_odometer
+    gyro_odometer_node
+  )
+endif()
+
+
+ament_auto_package(INSTALL_TO_SHARE
+  launch
+)

--- a/aichallenge/workspace/src/aichallenge_submit/gyro_odometer/README.md
+++ b/aichallenge/workspace/src/aichallenge_submit/gyro_odometer/README.md
@@ -1,0 +1,39 @@
+# gyro_odometer
+
+## Purpose
+
+`gyro_odometer` is the package to estimate twist by combining imu and vehicle speed.
+
+## Inputs / Outputs
+
+### Input
+
+| Name                            | Type                                             | Description                        |
+| ------------------------------- | ------------------------------------------------ | ---------------------------------- |
+| `vehicle/twist_with_covariance` | `geometry_msgs::msg::TwistWithCovarianceStamped` | twist with covariance from vehicle |
+| `imu`                           | `sensor_msgs::msg::Imu`                          | imu from sensor                    |
+
+### Output
+
+| Name                    | Type                                             | Description                     |
+| ----------------------- | ------------------------------------------------ | ------------------------------- |
+| `twist_with_covariance` | `geometry_msgs::msg::TwistWithCovarianceStamped` | estimated twist with covariance |
+
+## Parameters
+
+| Parameter             | Type   | Description                      |
+| --------------------- | ------ | -------------------------------- |
+| `output_frame`        | String | output's frame id                |
+| `message_timeout_sec` | Double | delay tolerance time for message |
+
+## Assumptions / Known limits
+
+- [Assumption] The frame_id of input twist message must be set to base_link.
+
+- [Assumption] The covariance in the input messages must be properly assigned.
+
+- [Assumption] The angular velocity is set to zero if both the longitudinal vehicle velocity and the angular velocity around the yaw axis are sufficiently small. This is for suppression of the IMU angular velocity bias. Without this process, we misestimate the vehicle status when stationary.
+
+- [Limitation] The frequency of the output messages depends on the frequency of the input IMU message.
+
+- [Limitation] We cannot produce reliable values for the lateral and vertical velocities. Therefore we assign large values to the corresponding elements in the output covariance matrix.

--- a/aichallenge/workspace/src/aichallenge_submit/gyro_odometer/include/gyro_odometer/gyro_odometer_core.hpp
+++ b/aichallenge/workspace/src/aichallenge_submit/gyro_odometer/include/gyro_odometer/gyro_odometer_core.hpp
@@ -1,0 +1,76 @@
+// Copyright 2015-2019 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GYRO_ODOMETER__GYRO_ODOMETER_CORE_HPP_
+#define GYRO_ODOMETER__GYRO_ODOMETER_CORE_HPP_
+
+#include "tier4_autoware_utils/ros/transform_listener.hpp"
+#include "tier4_autoware_utils/tier4_autoware_utils.hpp"
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <geometry_msgs/msg/twist_stamped.hpp>
+#include <geometry_msgs/msg/twist_with_covariance_stamped.hpp>
+#include <sensor_msgs/msg/imu.hpp>
+
+#include <tf2/transform_datatypes.h>
+#ifdef ROS_DISTRO_GALACTIC
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#else
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#endif
+
+#include <deque>
+#include <memory>
+#include <string>
+
+class GyroOdometer : public rclcpp::Node
+{
+private:
+  using COV_IDX = tier4_autoware_utils::xyz_covariance_index::XYZ_COV_IDX;
+
+public:
+  explicit GyroOdometer(const rclcpp::NodeOptions & options);
+  ~GyroOdometer();
+
+private:
+  void callbackVehicleTwist(
+    const geometry_msgs::msg::TwistWithCovarianceStamped::ConstSharedPtr vehicle_twist_msg_ptr);
+  void callbackImu(const sensor_msgs::msg::Imu::ConstSharedPtr imu_msg_ptr);
+  void publishData(const geometry_msgs::msg::TwistWithCovarianceStamped & twist_with_cov_raw);
+
+  rclcpp::Subscription<geometry_msgs::msg::TwistWithCovarianceStamped>::SharedPtr
+    vehicle_twist_sub_;
+  rclcpp::Subscription<sensor_msgs::msg::Imu>::SharedPtr imu_sub_;
+
+  rclcpp::Publisher<geometry_msgs::msg::TwistStamped>::SharedPtr twist_raw_pub_;
+  rclcpp::Publisher<geometry_msgs::msg::TwistWithCovarianceStamped>::SharedPtr
+    twist_with_covariance_raw_pub_;
+
+  rclcpp::Publisher<geometry_msgs::msg::TwistStamped>::SharedPtr twist_pub_;
+  rclcpp::Publisher<geometry_msgs::msg::TwistWithCovarianceStamped>::SharedPtr
+    twist_with_covariance_pub_;
+
+  std::shared_ptr<tier4_autoware_utils::TransformListener> transform_listener_;
+
+  std::string output_frame_;
+  double message_timeout_sec_;
+
+  bool vehicle_twist_arrived_;
+  bool imu_arrived_;
+  std::deque<geometry_msgs::msg::TwistWithCovarianceStamped> vehicle_twist_queue_;
+  std::deque<sensor_msgs::msg::Imu> gyro_queue_;
+};
+
+#endif  // GYRO_ODOMETER__GYRO_ODOMETER_CORE_HPP_

--- a/aichallenge/workspace/src/aichallenge_submit/gyro_odometer/launch/gyro_odometer.launch.xml
+++ b/aichallenge/workspace/src/aichallenge_submit/gyro_odometer/launch/gyro_odometer.launch.xml
@@ -1,0 +1,29 @@
+<launch>
+  <arg name="input_vehicle_twist_with_covariance_topic" default="/sensing/vehicle_velocity_converter/twist_with_covariance" description="input twist with covariance topic name from vehicle"/>
+
+  <arg name="input_imu_topic" default="/sensing/imu/imu_data" description="input imu topic name"/>
+
+  <arg name="output_twist_raw_topic" default="gyro_twist_raw" description="output raw twist topic name"/>
+  <arg name="output_twist_with_covariance_raw_topic" default="gyro_twist_with_covariance_raw" description="output raw twist with covariance topic name"/>
+
+  <arg name="output_twist_topic" default="gyro_twist" description="output twist topic name"/>
+  <arg name="output_twist_with_covariance_topic" default="gyro_twist_with_covariance" description="output twist with covariance topic name"/>
+
+  <arg name="output_frame" default="base_link" description="output frame id"/>
+  <arg name="message_timeout_sec" default="0.2" description="delay tolerance time for message"/>
+
+  <node pkg="gyro_odometer" exec="gyro_odometer" name="gyro_odometer" output="screen">
+    <remap from="vehicle/twist_with_covariance" to="$(var input_vehicle_twist_with_covariance_topic)"/>
+
+    <remap from="imu" to="$(var input_imu_topic)"/>
+
+    <remap from="twist_raw" to="$(var output_twist_raw_topic)"/>
+    <remap from="twist_with_covariance_raw" to="$(var output_twist_with_covariance_raw_topic)"/>
+
+    <remap from="twist" to="$(var output_twist_topic)"/>
+    <remap from="twist_with_covariance" to="$(var output_twist_with_covariance_topic)"/>
+
+    <param name="output_frame" value="$(var output_frame)"/>
+    <param name="message_timeout_sec" value="$(var message_timeout_sec)"/>
+  </node>
+</launch>

--- a/aichallenge/workspace/src/aichallenge_submit/gyro_odometer/package.xml
+++ b/aichallenge/workspace/src/aichallenge_submit/gyro_odometer/package.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>gyro_odometer</name>
+  <version>0.1.0</version>
+  <description>The gyro_odometer package as a ROS2 node</description>
+  <maintainer email="yamato.ando@tier4.jp">Yamato Ando</maintainer>
+  <license>Apache License 2.0</license>
+  <author email="yamato.ando@tier4.jp">Yamato Ando</author>
+
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
+
+  <build_depend>autoware_cmake</build_depend>
+
+  <depend>fmt</depend>
+  <depend>geometry_msgs</depend>
+  <depend>sensor_msgs</depend>
+  <depend>std_msgs</depend>
+  <depend>tf2</depend>
+  <depend>tf2_geometry_msgs</depend>
+  <depend>tf2_ros</depend>
+  <depend>tier4_autoware_utils</depend>
+
+  <exec_depend>rclcpp</exec_depend>
+  <exec_depend>rclcpp_components</exec_depend>
+
+  <test_depend>ament_cmake_ros</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>autoware_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/aichallenge/workspace/src/aichallenge_submit/gyro_odometer/src/gyro_odometer_core.cpp
+++ b/aichallenge/workspace/src/aichallenge_submit/gyro_odometer/src/gyro_odometer_core.cpp
@@ -1,0 +1,268 @@
+// Copyright 2015-2019 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "gyro_odometer/gyro_odometer_core.hpp"
+
+#ifdef ROS_DISTRO_GALACTIC
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#else
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#endif
+#include <fmt/core.h>
+
+#include <cmath>
+#include <memory>
+#include <string>
+
+std::array<double, 9> transformCovariance(const std::array<double, 9> & cov)
+{
+  using COV_IDX = tier4_autoware_utils::xyz_covariance_index::XYZ_COV_IDX;
+
+  double max_cov = std::max({cov[COV_IDX::X_X], cov[COV_IDX::Y_Y], cov[COV_IDX::Z_Z], 0.0009});
+
+  std::array<double, 9> cov_transformed;
+  cov_transformed.fill(0.);
+  cov_transformed[COV_IDX::X_X] = max_cov;
+  cov_transformed[COV_IDX::Y_Y] = max_cov;
+  cov_transformed[COV_IDX::Z_Z] = max_cov;
+  return cov_transformed;
+}
+
+geometry_msgs::msg::TwistWithCovarianceStamped concatGyroAndOdometer(
+  const std::deque<geometry_msgs::msg::TwistWithCovarianceStamped> & vehicle_twist_queue,
+  const std::deque<sensor_msgs::msg::Imu> & gyro_queue)
+{
+  using COV_IDX_XYZ = tier4_autoware_utils::xyz_covariance_index::XYZ_COV_IDX;
+  using COV_IDX_XYZRPY = tier4_autoware_utils::xyzrpy_covariance_index::XYZRPY_COV_IDX;
+
+  double vx_mean = 0;
+  geometry_msgs::msg::Vector3 gyro_mean{};
+  double vx_covariance_original = 0;
+  geometry_msgs::msg::Vector3 gyro_covariance_original{};
+  for (const auto & vehicle_twist : vehicle_twist_queue) {
+    vx_mean += vehicle_twist.twist.twist.linear.x;
+    vx_covariance_original += vehicle_twist.twist.covariance[0 * 6 + 0];
+  }
+  vx_mean /= vehicle_twist_queue.size();
+  vx_covariance_original /= vehicle_twist_queue.size();
+
+  for (const auto & gyro : gyro_queue) {
+    gyro_mean.x += gyro.angular_velocity.x;
+    gyro_mean.y += gyro.angular_velocity.y;
+    gyro_mean.z += gyro.angular_velocity.z;
+    gyro_covariance_original.x += gyro.angular_velocity_covariance[COV_IDX_XYZ::X_X];
+    gyro_covariance_original.y += gyro.angular_velocity_covariance[COV_IDX_XYZ::Y_Y];
+    gyro_covariance_original.z += gyro.angular_velocity_covariance[COV_IDX_XYZ::Z_Z];
+  }
+  gyro_mean.x /= gyro_queue.size();
+  gyro_mean.y /= gyro_queue.size();
+  gyro_mean.z /= gyro_queue.size();
+  gyro_covariance_original.x /= gyro_queue.size();
+  gyro_covariance_original.y /= gyro_queue.size();
+  gyro_covariance_original.z /= gyro_queue.size();
+
+  geometry_msgs::msg::TwistWithCovarianceStamped twist_with_cov;
+  const auto latest_vehicle_twist_stamp = rclcpp::Time(vehicle_twist_queue.back().header.stamp);
+  const auto latest_imu_stamp = rclcpp::Time(gyro_queue.back().header.stamp);
+  if (latest_vehicle_twist_stamp < latest_imu_stamp) {
+    twist_with_cov.header.stamp = latest_imu_stamp;
+  } else {
+    twist_with_cov.header.stamp = latest_vehicle_twist_stamp;
+  }
+  twist_with_cov.header.frame_id = gyro_queue.front().header.frame_id;
+  twist_with_cov.twist.twist.linear.x = vx_mean;
+  twist_with_cov.twist.twist.angular = gyro_mean;
+
+  // From a statistical point of view, here we reduce the covariances according to the number of
+  // observed data
+  twist_with_cov.twist.covariance[COV_IDX_XYZRPY::X_X] =
+    vx_covariance_original / vehicle_twist_queue.size();
+  twist_with_cov.twist.covariance[COV_IDX_XYZRPY::Y_Y] = 100000.0;
+  twist_with_cov.twist.covariance[COV_IDX_XYZRPY::Z_Z] = 100000.0;
+  twist_with_cov.twist.covariance[COV_IDX_XYZRPY::ROLL_ROLL] =
+    gyro_covariance_original.x / gyro_queue.size();
+  twist_with_cov.twist.covariance[COV_IDX_XYZRPY::PITCH_PITCH] =
+    gyro_covariance_original.y / gyro_queue.size();
+  twist_with_cov.twist.covariance[COV_IDX_XYZRPY::YAW_YAW] =
+    gyro_covariance_original.z / gyro_queue.size();
+
+  return twist_with_cov;
+}
+
+GyroOdometer::GyroOdometer(const rclcpp::NodeOptions & options)
+: Node("gyro_odometer", options),
+  output_frame_(declare_parameter("base_link", "base_link")),
+  message_timeout_sec_(declare_parameter("message_timeout_sec", 0.2)),
+  vehicle_twist_arrived_(false),
+  imu_arrived_(false)
+{
+  transform_listener_ = std::make_shared<tier4_autoware_utils::TransformListener>(this);
+
+  vehicle_twist_sub_ = create_subscription<geometry_msgs::msg::TwistWithCovarianceStamped>(
+    "vehicle/twist_with_covariance", rclcpp::QoS{100},
+    std::bind(&GyroOdometer::callbackVehicleTwist, this, std::placeholders::_1));
+
+  imu_sub_ = create_subscription<sensor_msgs::msg::Imu>(
+    "imu", rclcpp::QoS{100}, std::bind(&GyroOdometer::callbackImu, this, std::placeholders::_1));
+
+  twist_raw_pub_ = create_publisher<geometry_msgs::msg::TwistStamped>("twist_raw", rclcpp::QoS{10});
+  twist_with_covariance_raw_pub_ = create_publisher<geometry_msgs::msg::TwistWithCovarianceStamped>(
+    "twist_with_covariance_raw", rclcpp::QoS{10});
+
+  twist_pub_ = create_publisher<geometry_msgs::msg::TwistStamped>("twist", rclcpp::QoS{10});
+  twist_with_covariance_pub_ = create_publisher<geometry_msgs::msg::TwistWithCovarianceStamped>(
+    "twist_with_covariance", rclcpp::QoS{10});
+
+  // TODO(YamatoAndo) createTimer
+}
+
+GyroOdometer::~GyroOdometer() {}
+
+void GyroOdometer::callbackVehicleTwist(
+  const geometry_msgs::msg::TwistWithCovarianceStamped::ConstSharedPtr vehicle_twist_ptr)
+{
+  vehicle_twist_arrived_ = true;
+  if (!imu_arrived_) {
+    RCLCPP_WARN_THROTTLE(this->get_logger(), *this->get_clock(), 1000, "Imu msg is not subscribed");
+    vehicle_twist_queue_.clear();
+    gyro_queue_.clear();
+    return;
+  }
+
+  const double twist_dt = std::abs((this->now() - vehicle_twist_ptr->header.stamp).seconds());
+  if (twist_dt > message_timeout_sec_) {
+    const std::string error_msg = fmt::format(
+      "Twist msg is timeout. twist_dt: {}[sec], tolerance {}[sec]", twist_dt, message_timeout_sec_);
+    RCLCPP_ERROR_THROTTLE(this->get_logger(), *this->get_clock(), 1000, error_msg.c_str());
+    vehicle_twist_queue_.clear();
+    gyro_queue_.clear();
+    return;
+  }
+
+  vehicle_twist_queue_.push_back(*vehicle_twist_ptr);
+
+  if (gyro_queue_.empty()) return;
+  const double imu_dt = std::abs((this->now() - gyro_queue_.back().header.stamp).seconds());
+  if (imu_dt > message_timeout_sec_) {
+    const std::string error_msg = fmt::format(
+      "Imu msg is timeout. twist_dt: {}[sec], tolerance {}[sec]", imu_dt, message_timeout_sec_);
+    RCLCPP_ERROR_THROTTLE(this->get_logger(), *this->get_clock(), 1000, error_msg.c_str());
+    vehicle_twist_queue_.clear();
+    gyro_queue_.clear();
+    return;
+  }
+
+  const geometry_msgs::msg::TwistWithCovarianceStamped twist_with_cov_raw =
+    concatGyroAndOdometer(vehicle_twist_queue_, gyro_queue_);
+  publishData(twist_with_cov_raw);
+  vehicle_twist_queue_.clear();
+  gyro_queue_.clear();
+}
+
+void GyroOdometer::callbackImu(const sensor_msgs::msg::Imu::ConstSharedPtr imu_msg_ptr)
+{
+  imu_arrived_ = true;
+  if (!vehicle_twist_arrived_) {
+    RCLCPP_WARN_THROTTLE(
+      this->get_logger(), *this->get_clock(), 1000, "Twist msg is not subscribed");
+    vehicle_twist_queue_.clear();
+    gyro_queue_.clear();
+    return;
+  }
+
+  const double imu_dt = std::abs((this->now() - imu_msg_ptr->header.stamp).seconds());
+  if (imu_dt > message_timeout_sec_) {
+    const std::string error_msg = fmt::format(
+      "Imu msg is timeout. imu_dt: {}[sec], tolerance {}[sec]", imu_dt, message_timeout_sec_);
+    RCLCPP_ERROR_THROTTLE(this->get_logger(), *this->get_clock(), 1000, error_msg.c_str());
+    vehicle_twist_queue_.clear();
+    gyro_queue_.clear();
+    return;
+  }
+
+  geometry_msgs::msg::TransformStamped::ConstSharedPtr tf_imu2base_ptr =
+    transform_listener_->getLatestTransform(imu_msg_ptr->header.frame_id, output_frame_);
+  if (!tf_imu2base_ptr) {
+    RCLCPP_ERROR(
+      this->get_logger(), "Please publish TF %s to %s", output_frame_.c_str(),
+      (imu_msg_ptr->header.frame_id).c_str());
+    vehicle_twist_queue_.clear();
+    gyro_queue_.clear();
+    return;
+  }
+
+  geometry_msgs::msg::Vector3Stamped angular_velocity;
+  angular_velocity.header = imu_msg_ptr->header;
+  angular_velocity.vector = imu_msg_ptr->angular_velocity;
+
+  geometry_msgs::msg::Vector3Stamped transformed_angular_velocity;
+  transformed_angular_velocity.header = tf_imu2base_ptr->header;
+  tf2::doTransform(angular_velocity, transformed_angular_velocity, *tf_imu2base_ptr);
+
+  sensor_msgs::msg::Imu gyro_base_link;
+  gyro_base_link.header = imu_msg_ptr->header;
+  gyro_base_link.header.frame_id = output_frame_;
+  gyro_base_link.angular_velocity = transformed_angular_velocity.vector;
+  gyro_base_link.angular_velocity_covariance =
+    transformCovariance(imu_msg_ptr->angular_velocity_covariance);
+
+  gyro_queue_.push_back(gyro_base_link);
+
+  if (vehicle_twist_queue_.empty()) return;
+  const double twist_dt =
+    std::abs((this->now() - vehicle_twist_queue_.back().header.stamp).seconds());
+  if (twist_dt > message_timeout_sec_) {
+    const std::string error_msg = fmt::format(
+      "Twist msg is timeout. twist_dt: {}[sec], tolerance {}[sec]", twist_dt, message_timeout_sec_);
+    RCLCPP_ERROR_THROTTLE(this->get_logger(), *this->get_clock(), 1000, error_msg.c_str());
+    vehicle_twist_queue_.clear();
+    gyro_queue_.clear();
+    return;
+  }
+
+  const geometry_msgs::msg::TwistWithCovarianceStamped twist_with_cov_raw =
+    concatGyroAndOdometer(vehicle_twist_queue_, gyro_queue_);
+  publishData(twist_with_cov_raw);
+  vehicle_twist_queue_.clear();
+  gyro_queue_.clear();
+}
+
+void GyroOdometer::publishData(
+  const geometry_msgs::msg::TwistWithCovarianceStamped & twist_with_cov_raw)
+{
+  geometry_msgs::msg::TwistStamped twist_raw;
+  twist_raw.header = twist_with_cov_raw.header;
+  twist_raw.twist = twist_with_cov_raw.twist.twist;
+
+  twist_raw_pub_->publish(twist_raw);
+  twist_with_covariance_raw_pub_->publish(twist_with_cov_raw);
+
+  geometry_msgs::msg::TwistWithCovarianceStamped twist_with_covariance = twist_with_cov_raw;
+  geometry_msgs::msg::TwistStamped twist = twist_raw;
+
+  // clear imu yaw bias if vehicle is stopped
+  if (
+    std::fabs(twist_with_cov_raw.twist.twist.angular.z) < 0.01 &&
+    std::fabs(twist_with_cov_raw.twist.twist.linear.x) < 0.01) {
+    twist.twist.angular.x = 0.0;
+    twist.twist.angular.y = 0.0;
+    twist.twist.angular.z = 0.0;
+    twist_with_covariance.twist.twist.angular.x = 0.0;
+    twist_with_covariance.twist.twist.angular.y = 0.0;
+    twist_with_covariance.twist.twist.angular.z = 0.0;
+  }
+
+  twist_pub_->publish(twist);
+  twist_with_covariance_pub_->publish(twist_with_covariance);
+}

--- a/aichallenge/workspace/src/aichallenge_submit/gyro_odometer/src/gyro_odometer_core.cpp
+++ b/aichallenge/workspace/src/aichallenge_submit/gyro_odometer/src/gyro_odometer_core.cpp
@@ -264,8 +264,8 @@ void GyroOdometer::publishData(
 
   twist.twist.angular.x = 0.0;
   twist.twist.angular.y = 0.0;
-  twist_with_covariance.twist.twist.angular.x = 0.00001;
-  twist_with_covariance.twist.twist.angular.y = 0.00001;
+  twist_with_covariance.twist.twist.angular.x = 0.0;
+  twist_with_covariance.twist.twist.angular.y = 0.0;
   twist_pub_->publish(twist);
   twist_with_covariance_pub_->publish(twist_with_covariance);
 }

--- a/aichallenge/workspace/src/aichallenge_submit/gyro_odometer/src/gyro_odometer_core.cpp
+++ b/aichallenge/workspace/src/aichallenge_submit/gyro_odometer/src/gyro_odometer_core.cpp
@@ -263,6 +263,10 @@ void GyroOdometer::publishData(
     twist_with_covariance.twist.twist.angular.z = 0.0;
   }
 
+  twist.twist.angular.x = 0.0;
+  twist.twist.angular.y = 0.0;
+  twist_with_covariance.twist.twist.angular.x = 0.00001;
+  twist_with_covariance.twist.twist.angular.y = 0.00001;
   twist_pub_->publish(twist);
   twist_with_covariance_pub_->publish(twist_with_covariance);
 }

--- a/aichallenge/workspace/src/aichallenge_submit/gyro_odometer/src/gyro_odometer_core.cpp
+++ b/aichallenge/workspace/src/aichallenge_submit/gyro_odometer/src/gyro_odometer_core.cpp
@@ -29,7 +29,6 @@ std::array<double, 9> transformCovariance(const std::array<double, 9> & cov)
 {
   using COV_IDX = tier4_autoware_utils::xyz_covariance_index::XYZ_COV_IDX;
 
-  double max_cov = std::max({cov[COV_IDX::X_X], cov[COV_IDX::Y_Y], cov[COV_IDX::Z_Z], 0.0009});
 
   std::array<double, 9> cov_transformed;
   cov_transformed.fill(0.);

--- a/aichallenge/workspace/src/aichallenge_submit/gyro_odometer/src/gyro_odometer_node.cpp
+++ b/aichallenge/workspace/src/aichallenge_submit/gyro_odometer/src/gyro_odometer_node.cpp
@@ -1,0 +1,30 @@
+// Copyright 2015-2019 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "gyro_odometer/gyro_odometer_core.hpp"
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <memory>
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  rclcpp::NodeOptions options;
+  auto node = std::make_shared<GyroOdometer>(options);
+  rclcpp::spin(node);
+  rclcpp::shutdown();
+
+  return 0;
+}

--- a/aichallenge/workspace/src/aichallenge_submit/gyro_odometer/test/test_gyro_odometer_helper.cpp
+++ b/aichallenge/workspace/src/aichallenge_submit/gyro_odometer/test/test_gyro_odometer_helper.cpp
@@ -1,0 +1,46 @@
+// Copyright 2023 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "test_gyro_odometer_helper.hpp"
+
+using geometry_msgs::msg::TwistWithCovarianceStamped;
+using sensor_msgs::msg::Imu;
+
+Imu generateSampleImu()
+{
+  Imu imu;
+  imu.header.frame_id = "base_link";
+  imu.angular_velocity.x = 0.1;
+  imu.angular_velocity.y = 0.2;
+  imu.angular_velocity.z = 0.3;
+  return imu;
+}
+
+TwistWithCovarianceStamped generateSampleVelocity()
+{
+  TwistWithCovarianceStamped twist;
+  twist.header.frame_id = "base_link";
+  twist.twist.twist.linear.x = 1.0;
+  return twist;
+}
+
+rclcpp::NodeOptions getNodeOptionsWithDefaultParams()
+{
+  rclcpp::NodeOptions node_options;
+
+  // for gyro_odometer
+  node_options.append_parameter_override("output_frame", "base_link");
+  node_options.append_parameter_override("message_timeout_sec", 1e12);
+  return node_options;
+}

--- a/aichallenge/workspace/src/aichallenge_submit/gyro_odometer/test/test_gyro_odometer_helper.hpp
+++ b/aichallenge/workspace/src/aichallenge_submit/gyro_odometer/test/test_gyro_odometer_helper.hpp
@@ -1,0 +1,30 @@
+// Copyright 2023 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TEST_GYRO_ODOMETER_HELPER_HPP_
+#define TEST_GYRO_ODOMETER_HELPER_HPP_
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <geometry_msgs/msg/twist_with_covariance_stamped.hpp>
+#include <sensor_msgs/msg/imu.hpp>
+
+using geometry_msgs::msg::TwistWithCovarianceStamped;
+using sensor_msgs::msg::Imu;
+
+Imu generateSampleImu();
+TwistWithCovarianceStamped generateSampleVelocity();
+rclcpp::NodeOptions getNodeOptionsWithDefaultParams();
+
+#endif  // TEST_GYRO_ODOMETER_HELPER_HPP_

--- a/aichallenge/workspace/src/aichallenge_submit/gyro_odometer/test/test_gyro_odometer_pubsub.cpp
+++ b/aichallenge/workspace/src/aichallenge_submit/gyro_odometer/test/test_gyro_odometer_pubsub.cpp
@@ -1,0 +1,151 @@
+// Copyright 2023 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "gyro_odometer/gyro_odometer_core.hpp"
+#include "test_gyro_odometer_helper.hpp"
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <vector>
+
+/*
+ * This test checks if twist is published from gyro_odometer
+ */
+using geometry_msgs::msg::TwistWithCovarianceStamped;
+using sensor_msgs::msg::Imu;
+
+class ImuGenerator : public rclcpp::Node
+{
+public:
+  ImuGenerator() : Node("imu_generator"), imu_pub(create_publisher<Imu>("/imu", 1)) {}
+  rclcpp::Publisher<Imu>::SharedPtr imu_pub;
+};
+
+class VelocityGenerator : public rclcpp::Node
+{
+public:
+  VelocityGenerator()
+  : Node("velocity_generator"),
+    vehicle_velocity_pub(
+      create_publisher<TwistWithCovarianceStamped>("/vehicle/twist_with_covariance", 1))
+  {
+  }
+  rclcpp::Publisher<TwistWithCovarianceStamped>::SharedPtr vehicle_velocity_pub;
+};
+
+class GyroOdometerValidator : public rclcpp::Node
+{
+public:
+  GyroOdometerValidator() : Node("gyro_odometer_validator"), received_latest_twist_ptr(nullptr)
+  {
+    twist_sub = create_subscription<TwistWithCovarianceStamped>(
+      "/twist_with_covariance", 1, [this](const TwistWithCovarianceStamped::ConstSharedPtr msg) {
+        received_latest_twist_ptr = msg;
+      });
+  }
+
+  rclcpp::Subscription<TwistWithCovarianceStamped>::SharedPtr twist_sub;
+  TwistWithCovarianceStamped::ConstSharedPtr received_latest_twist_ptr;
+};
+
+void spinSome(rclcpp::Node::SharedPtr node_ptr)
+{
+  for (int i = 0; i < 50; ++i) {
+    rclcpp::spin_some(node_ptr);
+    rclcpp::WallRate(100).sleep();
+  }
+}
+
+bool isTwistValid(
+  const TwistWithCovarianceStamped & twist, const TwistWithCovarianceStamped & twist_ground_truth)
+{
+  if (twist.twist.twist.linear.x != twist_ground_truth.twist.twist.linear.x) {
+    return false;
+  }
+  if (twist.twist.twist.linear.y != twist_ground_truth.twist.twist.linear.y) {
+    return false;
+  }
+  if (twist.twist.twist.linear.z != twist_ground_truth.twist.twist.linear.z) {
+    return false;
+  }
+  if (twist.twist.twist.angular.x != twist_ground_truth.twist.twist.angular.x) {
+    return false;
+  }
+  if (twist.twist.twist.angular.y != twist_ground_truth.twist.twist.angular.y) {
+    return false;
+  }
+  if (twist.twist.twist.angular.z != twist_ground_truth.twist.twist.angular.z) {
+    return false;
+  }
+  return true;
+}
+
+// IMU & Velocity test
+// Verify that the gyro_odometer successfully publishes the fused twist message when both IMU and
+// velocity data are provided
+TEST(GyroOdometer, TestGyroOdometerWithImuAndVelocity)
+{
+  Imu input_imu = generateSampleImu();
+  TwistWithCovarianceStamped input_velocity = generateSampleVelocity();
+
+  TwistWithCovarianceStamped expected_output_twist;
+  expected_output_twist.twist.twist.linear.x = input_velocity.twist.twist.linear.x;
+  expected_output_twist.twist.twist.angular.x = input_imu.angular_velocity.x;
+  expected_output_twist.twist.twist.angular.y = input_imu.angular_velocity.y;
+  expected_output_twist.twist.twist.angular.z = input_imu.angular_velocity.z;
+
+  auto gyro_odometer_node = std::make_shared<GyroOdometer>(getNodeOptionsWithDefaultParams());
+  auto imu_generator = std::make_shared<ImuGenerator>();
+  auto velocity_generator = std::make_shared<VelocityGenerator>();
+  auto gyro_odometer_validator_node = std::make_shared<GyroOdometerValidator>();
+
+  velocity_generator->vehicle_velocity_pub->publish(
+    input_velocity);  // need this for now, which should eventually be removed
+  imu_generator->imu_pub->publish(input_imu);
+  velocity_generator->vehicle_velocity_pub->publish(input_velocity);
+
+  // gyro_odometer receives IMU and velocity, and publishes the fused twist data.
+  spinSome(gyro_odometer_node);
+
+  // validator node receives the fused twist data and store in "received_latest_twist_ptr".
+  spinSome(gyro_odometer_validator_node);
+
+  EXPECT_FALSE(gyro_odometer_validator_node->received_latest_twist_ptr == nullptr);
+  EXPECT_TRUE(isTwistValid(
+    *(gyro_odometer_validator_node->received_latest_twist_ptr), expected_output_twist));
+}
+
+// IMU-only test
+// Verify that the gyro_odometer does NOT publish any outputs when only IMU is provided
+TEST(GyroOdometer, TestGyroOdometerImuOnly)
+{
+  Imu input_imu = generateSampleImu();
+
+  auto gyro_odometer_node = std::make_shared<GyroOdometer>(getNodeOptionsWithDefaultParams());
+  auto imu_generator = std::make_shared<ImuGenerator>();
+  auto gyro_odometer_validator_node = std::make_shared<GyroOdometerValidator>();
+
+  imu_generator->imu_pub->publish(input_imu);
+
+  // gyro_odometer receives IMU
+  spinSome(gyro_odometer_node);
+
+  // validator node waits for the output fused twist from gyro_odometer
+  spinSome(gyro_odometer_validator_node);
+
+  EXPECT_TRUE(gyro_odometer_validator_node->received_latest_twist_ptr == nullptr);
+}

--- a/aichallenge/workspace/src/aichallenge_submit/gyro_odometer/test/test_main.cpp
+++ b/aichallenge/workspace/src/aichallenge_submit/gyro_odometer/test/test_main.cpp
@@ -1,0 +1,26 @@
+// Copyright 2023 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <gtest/gtest.h>
+
+int main(int argc, char ** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  rclcpp::init(argc, argv);
+  bool result = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return result;
+}

--- a/aichallenge/workspace/src/aichallenge_submit/imu_corrector/CMakeLists.txt
+++ b/aichallenge/workspace/src/aichallenge_submit/imu_corrector/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 3.14)
+project(imu_corrector)
+
+find_package(autoware_cmake REQUIRED)
+autoware_package()
+
+ament_auto_add_library(imu_corrector_node SHARED
+  src/imu_corrector_core.cpp
+  include/imu_corrector/imu_corrector_core.hpp
+)
+
+rclcpp_components_register_node(imu_corrector_node
+  PLUGIN "imu_corrector::ImuCorrector"
+  EXECUTABLE imu_corrector
+)
+
+ament_auto_package(INSTALL_TO_SHARE
+  launch
+  config
+)

--- a/aichallenge/workspace/src/aichallenge_submit/imu_corrector/README.md
+++ b/aichallenge/workspace/src/aichallenge_submit/imu_corrector/README.md
@@ -1,0 +1,58 @@
+# imu_corrector
+
+## Purpose
+
+`imu_corrector_node` is a node that correct imu data.
+
+1. Correct yaw rate offset $b$ by reading the parameter.
+2. Correct yaw rate standard deviation $\sigma$ by reading the parameter.
+
+Mathematically, we assume the following equation:
+
+$$
+\tilde{\omega}(t) = \omega(t) + b(t) + n(t)
+$$
+
+where $\tilde{\omega}$ denotes observed angular velocity, $\omega$ denotes true angular velocity, $b$ denotes an offset, and $n$ denotes a gaussian noise.
+We also assume that $n\sim\mathcal{N}(0, \sigma^2)$.
+
+<!-- TODO(TIER IV): Make this repository public or change the link. -->
+<!-- Use the value estimated by [deviation_estimator](https://github.com/tier4/calibration_tools/tree/main/localization/deviation_estimation_tools) as the parameters for this node. -->
+
+## Inputs / Outputs
+
+### Input
+
+| Name     | Type                    | Description  |
+| -------- | ----------------------- | ------------ |
+| `~input` | `sensor_msgs::msg::Imu` | raw imu data |
+
+### Output
+
+| Name      | Type                    | Description        |
+| --------- | ----------------------- | ------------------ |
+| `~output` | `sensor_msgs::msg::Imu` | corrected imu data |
+
+## Parameters
+
+### Core Parameters
+
+| Name                         | Type   | Description                                      |
+| ---------------------------- | ------ | ------------------------------------------------ |
+| `angular_velocity_offset_x`  | double | roll rate offset in imu_link [rad/s]             |
+| `angular_velocity_offset_y`  | double | pitch rate offset imu_link [rad/s]               |
+| `angular_velocity_offset_z`  | double | yaw rate offset imu_link [rad/s]                 |
+| `angular_velocity_stddev_xx` | double | roll rate standard deviation imu_link [rad/s]    |
+| `angular_velocity_stddev_yy` | double | pitch rate standard deviation imu_link [rad/s]   |
+| `angular_velocity_stddev_zz` | double | yaw rate standard deviation imu_link [rad/s]     |
+| `acceleration_stddev`        | double | acceleration standard deviation imu_link [m/s^2] |
+
+## Assumptions / Known limits
+
+## (Optional) Error detection and handling
+
+## (Optional) Performance characterization
+
+## (Optional) References/External links
+
+## (Optional) Future extensions / Unimplemented parts

--- a/aichallenge/workspace/src/aichallenge_submit/imu_corrector/config/imu_corrector.param.yaml
+++ b/aichallenge/workspace/src/aichallenge_submit/imu_corrector/config/imu_corrector.param.yaml
@@ -1,0 +1,8 @@
+/**:
+  ros__parameters:
+    angular_velocity_offset_x: 0.0    # [rad/s]
+    angular_velocity_offset_y: 0.0    # [rad/s]
+    angular_velocity_offset_z: 0.0    # [rad/s]
+    angular_velocity_stddev_xx: 0.03  # [rad/s]
+    angular_velocity_stddev_yy: 0.03  # [rad/s]
+    angular_velocity_stddev_zz: 0.03  # [rad/s]

--- a/aichallenge/workspace/src/aichallenge_submit/imu_corrector/include/imu_corrector/imu_corrector_core.hpp
+++ b/aichallenge/workspace/src/aichallenge_submit/imu_corrector/include/imu_corrector/imu_corrector_core.hpp
@@ -1,0 +1,62 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifndef IMU_CORRECTOR__IMU_CORRECTOR_CORE_HPP_
+#define IMU_CORRECTOR__IMU_CORRECTOR_CORE_HPP_
+
+#include "tier4_autoware_utils/ros/transform_listener.hpp"
+#include "tier4_autoware_utils/tier4_autoware_utils.hpp"
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <sensor_msgs/msg/imu.hpp>
+
+#include <tf2_ros/buffer.h>
+#include <tf2_ros/transform_listener.h>
+
+#include <memory>
+#include <string>
+
+namespace imu_corrector
+{
+class ImuCorrector : public rclcpp::Node
+{
+  using COV_IDX = tier4_autoware_utils::xyz_covariance_index::XYZ_COV_IDX;
+
+public:
+  explicit ImuCorrector(const rclcpp::NodeOptions & node_options);
+
+private:
+  void callbackImu(const sensor_msgs::msg::Imu::ConstSharedPtr imu_msg_ptr);
+
+  rclcpp::Subscription<sensor_msgs::msg::Imu>::SharedPtr imu_sub_;
+
+  rclcpp::Publisher<sensor_msgs::msg::Imu>::SharedPtr imu_pub_;
+
+  double angular_velocity_offset_x_imu_link_;
+  double angular_velocity_offset_y_imu_link_;
+  double angular_velocity_offset_z_imu_link_;
+
+  double angular_velocity_stddev_xx_imu_link_;
+  double angular_velocity_stddev_yy_imu_link_;
+  double angular_velocity_stddev_zz_imu_link_;
+
+  double accel_stddev_imu_link_;
+
+  std::shared_ptr<tier4_autoware_utils::TransformListener> transform_listener_;
+
+  std::string output_frame_;
+};
+}  // namespace imu_corrector
+
+#endif  // IMU_CORRECTOR__IMU_CORRECTOR_CORE_HPP_

--- a/aichallenge/workspace/src/aichallenge_submit/imu_corrector/launch/imu_corrector.launch.xml
+++ b/aichallenge/workspace/src/aichallenge_submit/imu_corrector/launch/imu_corrector.launch.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<launch>
+  <arg name="input_topic" default="imu_raw"/>
+  <arg name="output_topic" default="imu_data"/>
+  <arg name="param_file" default="$(find-pkg-share imu_corrector)/config/imu_corrector.param.yaml"/>
+
+  <node pkg="imu_corrector" exec="imu_corrector" name="imu_corrector" output="screen">
+    <remap from="input" to="$(var input_topic)"/>
+    <remap from="output" to="$(var output_topic)"/>
+    <param from="$(var param_file)"/>
+  </node>
+</launch>

--- a/aichallenge/workspace/src/aichallenge_submit/imu_corrector/package.xml
+++ b/aichallenge/workspace/src/aichallenge_submit/imu_corrector/package.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>imu_corrector</name>
+  <version>1.0.0</version>
+  <description>The ROS2 imu_corrector package</description>
+  <maintainer email="yamato.ando@tier4.jp">Yamato Ando</maintainer>
+  <license>Apache License 2.0</license>
+  <author email="yamato.ando@tier4.jp">Yamato Ando</author>
+
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
+
+  <build_depend>autoware_cmake</build_depend>
+
+  <depend>rclcpp</depend>
+  <depend>rclcpp_components</depend>
+  <depend>sensor_msgs</depend>
+  <depend>tf2</depend>
+  <depend>tf2_ros</depend>
+  <depend>tier4_autoware_utils</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>autoware_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/aichallenge/workspace/src/aichallenge_submit/imu_corrector/src/imu_corrector_core.cpp
+++ b/aichallenge/workspace/src/aichallenge_submit/imu_corrector/src/imu_corrector_core.cpp
@@ -1,0 +1,120 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "imu_corrector/imu_corrector_core.hpp"
+
+std::array<double, 9> transformCovariance(const std::array<double, 9> & cov)
+{
+  using COV_IDX = tier4_autoware_utils::xyz_covariance_index::XYZ_COV_IDX;
+
+  double max_cov = 0.0;
+  max_cov = std::max(max_cov, cov[COV_IDX::X_X]);
+  max_cov = std::max(max_cov, cov[COV_IDX::Y_Y]);
+  max_cov = std::max(max_cov, cov[COV_IDX::Z_Z]);
+
+  std::array<double, 9> cov_transformed;
+  cov_transformed.fill(0.);
+  cov_transformed[COV_IDX::X_X] = max_cov;
+  cov_transformed[COV_IDX::Y_Y] = max_cov;
+  cov_transformed[COV_IDX::Z_Z] = max_cov;
+  return cov_transformed;
+}
+
+geometry_msgs::msg::Vector3 transformVector3(
+  const geometry_msgs::msg::Vector3 & vec, const geometry_msgs::msg::TransformStamped & transform)
+{
+  geometry_msgs::msg::Vector3Stamped vec_stamped;
+  vec_stamped.vector = vec;
+
+  geometry_msgs::msg::Vector3Stamped vec_stamped_transformed;
+  tf2::doTransform(vec_stamped, vec_stamped_transformed, transform);
+  return vec_stamped_transformed.vector;
+}
+
+namespace imu_corrector
+{
+ImuCorrector::ImuCorrector(const rclcpp::NodeOptions & node_options)
+: Node("imu_corrector", node_options),
+  output_frame_(declare_parameter<std::string>("base_link", "base_link"))
+{
+  transform_listener_ = std::make_shared<tier4_autoware_utils::TransformListener>(this);
+
+  angular_velocity_offset_x_imu_link_ = declare_parameter<double>("angular_velocity_offset_x", 0.0);
+  angular_velocity_offset_y_imu_link_ = declare_parameter<double>("angular_velocity_offset_y", 0.0);
+  angular_velocity_offset_z_imu_link_ = declare_parameter<double>("angular_velocity_offset_z", 0.0);
+
+  angular_velocity_stddev_xx_imu_link_ =
+    declare_parameter<double>("angular_velocity_stddev_xx", 0.03);
+  angular_velocity_stddev_yy_imu_link_ =
+    declare_parameter<double>("angular_velocity_stddev_yy", 0.03);
+  angular_velocity_stddev_zz_imu_link_ =
+    declare_parameter<double>("angular_velocity_stddev_zz", 0.03);
+
+  accel_stddev_imu_link_ = declare_parameter<double>("acceleration_stddev", 10000.0);
+
+  imu_sub_ = create_subscription<sensor_msgs::msg::Imu>(
+    "input", rclcpp::QoS{1}, std::bind(&ImuCorrector::callbackImu, this, std::placeholders::_1));
+
+  imu_pub_ = create_publisher<sensor_msgs::msg::Imu>("output", rclcpp::QoS{10});
+}
+
+void ImuCorrector::callbackImu(const sensor_msgs::msg::Imu::ConstSharedPtr imu_msg_ptr)
+{
+  sensor_msgs::msg::Imu imu_msg;
+  imu_msg = *imu_msg_ptr;
+
+  imu_msg.angular_velocity.x -= angular_velocity_offset_x_imu_link_;
+  imu_msg.angular_velocity.y -= angular_velocity_offset_y_imu_link_;
+  imu_msg.angular_velocity.z -= angular_velocity_offset_z_imu_link_;
+
+  imu_msg.angular_velocity_covariance[COV_IDX::X_X] =
+    angular_velocity_stddev_xx_imu_link_ * angular_velocity_stddev_xx_imu_link_;
+  imu_msg.angular_velocity_covariance[COV_IDX::Y_Y] =
+    angular_velocity_stddev_yy_imu_link_ * angular_velocity_stddev_yy_imu_link_;
+  imu_msg.angular_velocity_covariance[COV_IDX::Z_Z] =
+    angular_velocity_stddev_zz_imu_link_ * angular_velocity_stddev_zz_imu_link_;
+  imu_msg.linear_acceleration_covariance[COV_IDX::X_X] =
+    accel_stddev_imu_link_ * accel_stddev_imu_link_;
+  imu_msg.linear_acceleration_covariance[COV_IDX::Y_Y] =
+    accel_stddev_imu_link_ * accel_stddev_imu_link_;
+  imu_msg.linear_acceleration_covariance[COV_IDX::Z_Z] =
+    accel_stddev_imu_link_ * accel_stddev_imu_link_;
+
+  geometry_msgs::msg::TransformStamped::ConstSharedPtr tf_imu2base_ptr =
+    transform_listener_->getLatestTransform(imu_msg.header.frame_id, output_frame_);
+  if (!tf_imu2base_ptr) {
+    RCLCPP_ERROR(
+      this->get_logger(), "Please publish TF %s to %s", output_frame_.c_str(),
+      (imu_msg.header.frame_id).c_str());
+    return;
+  }
+
+  sensor_msgs::msg::Imu imu_msg_base_link;
+  imu_msg_base_link.header.stamp = imu_msg_ptr->header.stamp;
+  imu_msg_base_link.header.frame_id = output_frame_;
+  imu_msg_base_link.linear_acceleration =
+    transformVector3(imu_msg.linear_acceleration, *tf_imu2base_ptr);
+  imu_msg_base_link.linear_acceleration_covariance =
+    transformCovariance(imu_msg.linear_acceleration_covariance);
+  imu_msg_base_link.angular_velocity = transformVector3(imu_msg.angular_velocity, *tf_imu2base_ptr);
+  imu_msg_base_link.angular_velocity_covariance =
+    transformCovariance(imu_msg.angular_velocity_covariance);
+
+  imu_pub_->publish(imu_msg_base_link);
+}
+
+}  // namespace imu_corrector
+
+#include <rclcpp_components/register_node_macro.hpp>
+RCLCPP_COMPONENTS_REGISTER_NODE(imu_corrector::ImuCorrector)

--- a/aichallenge/workspace/src/aichallenge_submit/imu_gnss_poser/src/imu_gnss_poser_node.cpp
+++ b/aichallenge/workspace/src/aichallenge_submit/imu_gnss_poser/src/imu_gnss_poser_node.cpp
@@ -1,5 +1,6 @@
 #include "rclcpp/rclcpp.hpp"
 #include "geometry_msgs/msg/pose_with_covariance_stamped.hpp"
+#include "geometry_msgs/msg/twist_with_covariance_stamped.hpp"
 #include "sensor_msgs/msg/imu.hpp"
 
 class ImuGnssPoser : public rclcpp::Node
@@ -10,6 +11,10 @@ public:
     {
         auto qos = rclcpp::QoS(rclcpp::KeepLast(10)).reliable();
         pub_pose_ = this->create_publisher<geometry_msgs::msg::PoseWithCovarianceStamped>("/localization/imu_gnss_poser/pose_with_covariance", qos);
+        pub_initial_pose_3d_ = this->create_publisher<geometry_msgs::msg::PoseWithCovarianceStamped>("/localization/initial_pose3d", qos);
+        sub_twist_ = this->create_subscription<geometry_msgs::msg::TwistWithCovarianceStamped>(
+            "/localization/twist_with_covariance", qos,
+            std::bind(&ImuGnssPoser::twist_callback, this, std::placeholders::_1)); 
         sub_gnss_ = this->create_subscription<geometry_msgs::msg::PoseWithCovarianceStamped>(
             "/sensing/gnss/pose_with_covariance", qos,
             std::bind(&ImuGnssPoser::gnss_callback, this, std::placeholders::_1));
@@ -32,19 +37,29 @@ private:
         msg->pose.covariance[7*4] = 0.1;
         msg->pose.covariance[7*5] = 1.0;
         pub_pose_->publish(*msg);
+        if (!is_ekf_initialized_)
+            pub_initial_pose_3d_->publish(*msg);
     }
 
     void imu_callback(sensor_msgs::msg::Imu::SharedPtr msg) {
         imu_msg_ = *msg;
     }
 
+    void twist_callback(const geometry_msgs::msg::TwistWithCovarianceStamped::SharedPtr msg)
+    {
+        is_ekf_initialized_ = true;
+    }
+
     rclcpp::Publisher<geometry_msgs::msg::PoseWithCovarianceStamped>::SharedPtr pub_pose_;
+    rclcpp::Publisher<geometry_msgs::msg::PoseWithCovarianceStamped>::SharedPtr pub_initial_pose_3d_;
     rclcpp::Subscription<geometry_msgs::msg::PoseWithCovarianceStamped>::SharedPtr sub_gnss_;
+    rclcpp::Subscription<geometry_msgs::msg::TwistWithCovarianceStamped>::SharedPtr sub_twist_;
     rclcpp::Subscription<sensor_msgs::msg::Imu>::SharedPtr sub_imu_;
     sensor_msgs::msg::Imu imu_msg_;
+    bool is_ekf_initialized_ = {false};
 };
 
-int main(int argc, char const *argv[])
+int main(int argc, char *argv[])
 {
     rclcpp::init(argc, argv);
     rclcpp::spin(std::make_shared<ImuGnssPoser>());

--- a/aichallenge/workspace/src/aichallenge_submit/imu_gnss_poser/src/imu_gnss_poser_node.cpp
+++ b/aichallenge/workspace/src/aichallenge_submit/imu_gnss_poser/src/imu_gnss_poser_node.cpp
@@ -30,12 +30,12 @@ private:
         msg->pose.pose.orientation.y = imu_msg_.orientation.y;
         msg->pose.pose.orientation.z = imu_msg_.orientation.z;
         msg->pose.pose.orientation.w = imu_msg_.orientation.w;
-        msg->pose.covariance[7*0] = 10.0;
-        msg->pose.covariance[7*1] = 10.0;
-        msg->pose.covariance[7*2] = 10.0;
-        msg->pose.covariance[7*3] = 0.1;
-        msg->pose.covariance[7*4] = 0.1;
-        msg->pose.covariance[7*5] = 1.0;
+        msg->pose.covariance[7*0] = 0.1;
+        msg->pose.covariance[7*1] = 0.1;
+        msg->pose.covariance[7*2] = 0.1;
+        msg->pose.covariance[7*3] = 0.01;
+        msg->pose.covariance[7*4] = 0.01;
+        msg->pose.covariance[7*5] = 0.1;
         pub_pose_->publish(*msg);
         if (!is_ekf_initialized_)
             pub_initial_pose_3d_->publish(*msg);

--- a/aichallenge/workspace/src/aichallenge_submit/racing_kart_sensor_kit_description/config/sensor_kit_calibration.yaml
+++ b/aichallenge/workspace/src/aichallenge_submit/racing_kart_sensor_kit_description/config/sensor_kit_calibration.yaml
@@ -12,4 +12,4 @@ sensor_kit_base_link:
     z: 0.0
     roll: 0.0
     pitch: 0.0
-    yaw: 3.14159265359
+    yaw: 0.0

--- a/aichallenge/workspace/src/aichallenge_submit/racing_kart_sensor_kit_description/config/sensor_kit_calibration.yaml
+++ b/aichallenge/workspace/src/aichallenge_submit/racing_kart_sensor_kit_description/config/sensor_kit_calibration.yaml
@@ -10,6 +10,6 @@ sensor_kit_base_link:
     x: 0.0
     y: 0.0
     z: 0.0
-    roll: 3.14159265359
+    roll: 0.0
     pitch: 0.0
     yaw: 3.14159265359


### PR DESCRIPTION
以下の点を修正
・ekfで毎回初期化処理が入っていた。
・covarianceの値が適切に設定されていなかった

- gyro odometor, imu correctorの追加
- sensor kitのconfig修正
- imuの共分散の設定
- ekfの修正
    - smooth step修正
    - 初期化処理の修正
- gnssの共分散変更
- pure pursuitのパラメータ調整
- ll2の微調整

[fix-ekf.webm](https://github.com/user-attachments/assets/8ac3d587-78f8-4f18-bfd1-ff6bf70ef3bb)

加速度、速度の比較
- before
![image](https://github.com/user-attachments/assets/f4608353-8599-43a1-bf9a-4b91a981caef)

- after
![image](https://github.com/user-attachments/assets/086b352d-2086-434e-a047-dadb41cfb3d5)
