### PR TITLE
fix: fix docker build warnings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,17 +10,17 @@ RUN apt-get -y install ros-humble-rqt-graph
 
 # PATH="$PATH:/root/.local/bin"
 # PATH="/usr/local/cuda/bin:$PATH"
-ENV XDG_RUNTIME_DIR /tmp/xdg
-ENV ROS_LOCALHOST_ONLY 1
-ENV RMW_IMPLEMENTATION rmw_cyclonedds_cpp
+ENV XDG_RUNTIME_DIR=/tmp/xdg
+ENV ROS_LOCALHOST_ONLY=1
+ENV RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
 
 FROM common AS dev
 
-ENV RCUTILS_COLORIZED_OUTPUT 1
+ENV RCUTILS_COLORIZED_OUTPUT=1
 
 FROM common AS eval
 
-ENV RCUTILS_COLORIZED_OUTPUT 0
+ENV RCUTILS_COLORIZED_OUTPUT=0
 
 RUN mkdir /ws
 RUN git clone --depth 1 https://github.com/AutomotiveAIChallenge/aichallenge-2024 /ws/repository


### PR DESCRIPTION
以下の警告が出ていたので修正しました。
```
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 13)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 14)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 15)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 19)
```