### PR TITLE
fix: modify the sensor position and orientation

### DIFF
--- a/aichallenge/workspace/src/aichallenge_submit/racing_kart_sensor_kit_description/config/sensors_calibration.yaml
+++ b/aichallenge/workspace/src/aichallenge_submit/racing_kart_sensor_kit_description/config/sensors_calibration.yaml
@@ -1,8 +1,8 @@
 base_link:
   sensor_kit_base_link:
-    x: 0.9
+    x: 0.0
     y: 0.0
-    z: 2.0
-    roll: -0.001
-    pitch: 0.015
-    yaw: -0.0364
+    z: 0.0
+    roll: 0.0
+    pitch: 0.0
+    yaw: 0.0


### PR DESCRIPTION
レーシングカートに搭載されたセンサーの位置姿勢を記載するsenros_calibration.yamlの値が、[AWSIMの設定](https://automotiveaichallenge.github.io/aichallenge-documentation-2024/specifications/simulator.html#imu)と異なっていたので修正しました。