### PR TITLE
fix: modify the tf of gnss

### DIFF
--- a/aichallenge/workspace/src/aichallenge_submit/racing_kart_sensor_kit_description/config/sensor_kit_calibration.yaml
+++ b/aichallenge/workspace/src/aichallenge_submit/racing_kart_sensor_kit_description/config/sensor_kit_calibration.yaml
@@ -1,8 +1,8 @@
 sensor_kit_base_link:
   gnss_link:
-    x: -0.1
+    x: 0.0
     y: 0.0
-    z: -0.2
+    z: 0.0
     roll: 0.0
     pitch: 0.0
     yaw: 0.0


### PR DESCRIPTION
gnssのtfをAWSIMに合わせました。
https://automotiveaichallenge.github.io/aichallenge-documentation-2024/specifications/simulator.html
![image](https://github.com/user-attachments/assets/b96ef951-c99a-42b0-a357-3f1774edf0a3)
