### PR TITLE
fix: modify vehicle info param

### DIFF
--- a/aichallenge/workspace/src/aichallenge_submit/racing_kart_description/config/vehicle_info.param.yaml
+++ b/aichallenge/workspace/src/aichallenge_submit/racing_kart_description/config/vehicle_info.param.yaml
@@ -1,12 +1,12 @@
 /**:
   ros__parameters:
-    wheel_radius: 0.255
-    wheel_width: 0.196
+    wheel_radius: 0.24
+    wheel_width: 0.18 # wheel width of the rear wheel
     wheel_base: 1.087 # between front wheel center and rear wheel center
-    wheel_tread: 0.975 # between left wheel center and right wheel center
+    wheel_tread: 1.12 # between rear left wheel center and rear right wheel center
     front_overhang: 0.467 # between front wheel center and vehicle front
     rear_overhang: 0.510 # between rear wheel center and vehicle rear
-    left_overhang: 0.145 # between left wheel center and vehicle left
-    right_overhang: 0.145 # between right wheel center and vehicle right
+    left_overhang: 0.09 # between rear left wheel center and vehicle left (the half of the rear wheel width)
+    right_overhang: 0.09 # between rear right wheel center and vehicle right (the half of the rear wheel width)
     vehicle_height: 2.2 # vehicle height + sensor_kit height
     max_steer_angle: 0.64 # [rad]


### PR DESCRIPTION
[AWSIM](https://automotiveaichallenge.github.io/aichallenge-documentation-2024/specifications/simulator.html)に合わせて以下のようにパラメータを変更しました。

- wheek_widthは後輪に合わせました（前輪でもいいらしいですが、base link基準で色々考えているので強いて言うなら後輪がいいらしいです）。
- wheel_treadは後輪に合わせました（safety boxの計算に使われるの大きい方を設定しました）
- overhangはタイヤ幅の半分にしました


front_overhang、rear_overhang、vehicle_heightがわからなかったので未修正です

![image](https://github.com/user-attachments/assets/6a47ef4d-b9e3-4323-9eff-05c11af4dced)
