### PR TITLE
chore(goal_pose_setter): add_info_throttle_for_goal_pose_setter

### DIFF
--- a/aichallenge/workspace/src/aichallenge_submit/goal_pose_setter/src/goal_pose_setter_node.cpp
+++ b/aichallenge/workspace/src/aichallenge_submit/goal_pose_setter/src/goal_pose_setter_node.cpp
@@ -89,7 +89,7 @@ void GoalPosePublisher::on_timer()
         msg->pose.orientation.w = this->get_parameter("goal.orientation.w").as_double();
 
         goal_publisher_->publish(*msg);
-        RCLCPP_INFO(this->get_logger(), "Publishing goal pose");
+        RCLCPP_INFO_THROTTLE(get_logger(), *get_clock(), 5000 /*ms*/, "Publishing goal pose");
     }
 }
 


### PR DESCRIPTION
- add info throttle for goal pose setter（実機での実験中ターミナルを独占するため、標準出力の間隔を設けました）

```
[simple_pure_pursuit-15] [0m[INFO] [1724221917.508347088] [simple_pure_pursuit_node]: trajectory is not available[0m
[goal_pose_setter_node-21] [0m[INFO] [1724221917.599452720] [goal_pose_setter]: Publishing goal pose[0m
[routing_adaptor-20] [0m[INFO] [1724221918.175216824] [default_ad_api.helpers.routing_adaptor]: client call: /api/routing/set_route_points[0m
```