### PR TITLE
fix: improve ekf_localizer processing time

### DIFF
--- a/aichallenge/workspace/src/aichallenge_launch/launch/aichallenge.launch.xml
+++ b/aichallenge/workspace/src/aichallenge_launch/launch/aichallenge.launch.xml
@@ -66,6 +66,7 @@
       <arg name="enable_yaw_bias_estimation" value="false"/>
       <arg name="tf_rate" value="50.0"/>
       <arg name="twist_smoothing_steps" value="1"/>
+      <arg name="pose_smoothing_steps" value="1"/>
       <arg name="input_initial_pose_name" value="/localization/initial_pose3d"/>
       <arg name="input_pose_with_cov_name" value="/localization/imu_gnss_poser/pose_with_covariance"/>
       <arg name="input_twist_with_cov_name" value="/localization/twist_estimator/twist_with_covariance"/>


### PR DESCRIPTION
Since the pose estimator outputs poses at 30 Hz (supposed to be published at 10Hz), the EKF localizer couldn't keep up. 
Therefore, I reduced the processing time by decreasing the smoothing steps. 