### PR TITLE
fix: ll2 interval

### DIFF
--- a/aichallenge/workspace/src/aichallenge_submit/aichallenge_submit_launch/map/lanelet2_map.osm
+++ b/aichallenge/workspace/src/aichallenge_submit/aichallenge_submit_launch/map/lanelet2_map.osm
@@ -1,5123 +1,3285 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <osm generator="VMB">
-  <MetaInfo format_version="1" map_version="13"/>
-  <node id="8" lat="35.62581952967" lon="139.78142932797">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <MetaInfo format_version="1" map_version="20"/>
+  <node id="8" lat="35.62581953015" lon="139.78142932763">
     <tag k="local_x" v="89653.9564"/>
     <tag k="local_y" v="43131.2322"/>
     <tag k="ele" v="43.217"/>
   </node>
-  <node id="9" lat="35.62578852796" lon="139.78142310661">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89653.3504"/>
-    <tag k="local_y" v="43127.8006"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="11" lat="35.62579839585" lon="139.78150047282">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="11" lat="35.62579839633" lon="139.78150047248">
     <tag k="local_x" v="89660.3701"/>
     <tag k="local_y" v="43128.8083"/>
     <tag k="ele" v="43.217"/>
   </node>
-  <node id="12" lat="35.62576282858" lon="139.78150254637">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="12" lat="35.62576282906" lon="139.78150254603">
     <tag k="local_x" v="89660.509"/>
     <tag k="local_y" v="43124.861"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="15" lat="35.62575661037" lon="139.78138062633">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="15" lat="35.62575661085" lon="139.78138062599">
     <tag k="local_x" v="89649.4596"/>
     <tag k="local_y" v="43124.3081"/>
     <tag k="ele" v="43.082"/>
   </node>
-  <node id="16" lat="35.62568721747" lon="139.78137263114">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="16" lat="35.62568721795" lon="139.7813726308">
     <tag k="local_x" v="89648.6402"/>
     <tag k="local_y" v="43116.6203"/>
     <tag k="ele" v="43.082"/>
   </node>
-  <node id="17" lat="35.62577805342" lon="139.78125691057">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="17" lat="35.62577805389" lon="139.78125691023">
     <tag k="local_x" v="89638.2856"/>
     <tag k="local_y" v="43126.8253"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="18" lat="35.62572501212" lon="139.78120422958">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="18" lat="35.6257250126" lon="139.78120422924">
     <tag k="local_x" v="89633.442"/>
     <tag k="local_y" v="43121.0013"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="19" lat="35.62608356538" lon="139.78100753039">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="19" lat="35.62608356586" lon="139.78100753005">
     <tag k="local_x" v="89616.1222"/>
     <tag k="local_y" v="43160.9913"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="20" lat="35.62605968924" lon="139.78093114301">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="20" lat="35.62605968972" lon="139.78093114267">
     <tag k="local_x" v="89609.1719"/>
     <tag k="local_y" v="43158.4288"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="21" lat="35.62610108709" lon="139.78103820928">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="21" lat="35.62610108757" lon="139.78103820894">
     <tag k="local_x" v="89618.9245"/>
     <tag k="local_y" v="43162.9003"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="22" lat="35.62614693642" lon="139.78110085958">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="22" lat="35.6261469369" lon="139.78110085924">
     <tag k="local_x" v="89624.661"/>
     <tag k="local_y" v="43167.9154"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="23" lat="35.62584769838" lon="139.7812417885">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="23" lat="35.62584769886" lon="139.78124178816">
     <tag k="local_x" v="89637.0119"/>
     <tag k="local_y" v="43134.567"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="24" lat="35.62589937924" lon="139.78128503001">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="24" lat="35.62589937972" lon="139.78128502967">
     <tag k="local_x" v="89640.9988"/>
     <tag k="local_y" v="43140.2507"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="25" lat="35.62593259201" lon="139.78139296917">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="25" lat="35.62593259248" lon="139.78139296883">
     <tag k="local_x" v="89650.8192"/>
     <tag k="local_y" v="43143.8134"/>
     <tag k="ele" v="43.146"/>
   </node>
-  <node id="26" lat="35.62591310667" lon="139.78132244838">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="26" lat="35.62591310715" lon="139.78132244804">
     <tag k="local_x" v="89644.4062"/>
     <tag k="local_y" v="43141.7313"/>
     <tag k="ele" v="43.146"/>
   </node>
-  <node id="27" lat="35.62621880367" lon="139.78115852238">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="27" lat="35.62621880415" lon="139.78115852204">
     <tag k="local_x" v="89629.9816"/>
     <tag k="local_y" v="43175.8219"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="28" lat="35.62617251732" lon="139.7811178127">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="28" lat="35.6261725178" lon="139.78111781236">
     <tag k="local_x" v="89626.2314"/>
     <tag k="local_y" v="43170.7337"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="29" lat="35.62624191965" lon="139.78108379343">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="29" lat="35.62624192013" lon="139.78108379309">
     <tag k="local_x" v="89623.2461"/>
     <tag k="local_y" v="43178.4697"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="30" lat="35.62623858923" lon="139.78100058209">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89615.7061"/>
+  <node id="30" lat="35.62623856736" lon="139.78099837355">
+    <tag k="local_x" v="89615.5061"/>
     <tag k="local_y" v="43178.1937"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="31" lat="35.62630476542" lon="139.78114517547">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89628.8911"/>
-    <tag k="local_y" v="43185.3714"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="32" lat="35.62629373598" lon="139.78131150461">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="32" lat="35.62629373646" lon="139.78131150427">
     <tag k="local_x" v="89643.9383"/>
     <tag k="local_y" v="43183.9614"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="33" lat="35.62599412239" lon="139.78160152345">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="33" lat="35.62599412287" lon="139.78160152311">
     <tag k="local_x" v="89669.79"/>
     <tag k="local_y" v="43150.4041"/>
     <tag k="ele" v="43.373"/>
   </node>
-  <node id="34" lat="35.6259339416" lon="139.7815349384">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="34" lat="35.62593394208" lon="139.78153493806">
     <tag k="local_x" v="89663.6775"/>
     <tag k="local_y" v="43143.8038"/>
     <tag k="ele" v="43.373"/>
   </node>
-  <node id="35" lat="35.62592316252" lon="139.78142061509">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="35" lat="35.625923163" lon="139.78142061475">
     <tag k="local_x" v="89653.3098"/>
     <tag k="local_y" v="43142.7365"/>
     <tag k="ele" v="43.22"/>
   </node>
-  <node id="36" lat="35.62591947663" lon="139.78149180557">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="36" lat="35.62591947711" lon="139.78149180523">
     <tag k="local_x" v="89659.7516"/>
     <tag k="local_y" v="43142.2478"/>
     <tag k="ele" v="43.22"/>
   </node>
-  <node id="37" lat="35.62617483459" lon="139.78101385704">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="37" lat="35.62617483507" lon="139.7810138567">
     <tag k="local_x" v="89616.8206"/>
     <tag k="local_y" v="43171.1074"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="38" lat="35.62614487787" lon="139.78094813082">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="38" lat="35.62614487835" lon="139.78094813048">
     <tag k="local_x" v="89610.8274"/>
     <tag k="local_y" v="43167.8585"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="39" lat="35.6261986677" lon="139.78103663738">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="39" lat="35.62619866818" lon="139.78103663704">
     <tag k="local_x" v="89618.9163"/>
     <tag k="local_y" v="43173.7253"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="40" lat="35.62631001988" lon="139.78100975083">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="40" lat="35.62631002036" lon="139.78100975049">
     <tag k="local_x" v="89616.6346"/>
     <tag k="local_y" v="43186.1062"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="41" lat="35.62636820982" lon="139.78110988173">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="41" lat="35.6263682103" lon="139.78110988139">
     <tag k="local_x" v="89625.7822"/>
     <tag k="local_y" v="43192.448"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="42" lat="35.62637784661" lon="139.78149161892">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="42" lat="35.62637784709" lon="139.78149161858">
     <tag k="local_x" v="89660.3646"/>
     <tag k="local_y" v="43193.0885"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="43" lat="35.62626896229" lon="139.78159198303">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="43" lat="35.62626896277" lon="139.78159198269">
     <tag k="local_x" v="89669.3037"/>
     <tag k="local_y" v="43180.8989"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="44" lat="35.6261325247" lon="139.78148459056">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="44" lat="35.62613252518" lon="139.78148459022">
     <tag k="local_x" v="89659.391"/>
     <tag k="local_y" v="43165.8863"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="45" lat="35.62621579977" lon="139.78160583003">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="45" lat="35.62621580025" lon="139.78160582969">
     <tag k="local_x" v="89670.4846"/>
     <tag k="local_y" v="43174.9868"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="46" lat="35.6260959611" lon="139.78175691886">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="46" lat="35.62609596158" lon="139.78175691852">
     <tag k="local_x" v="89684.0022"/>
     <tag k="local_y" v="43161.5253"/>
     <tag k="ele" v="42.0176"/>
   </node>
-  <node id="47" lat="35.62620582345" lon="139.78152469066">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="47" lat="35.62620582393" lon="139.78152469032">
     <tag k="local_x" v="89663.1231"/>
     <tag k="local_y" v="43173.9713"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="48" lat="35.62616548392" lon="139.78137363155">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="48" lat="35.6261654844" lon="139.78137363121">
     <tag k="local_x" v="89649.3881"/>
     <tag k="local_y" v="43169.6665"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="49" lat="35.62610371345" lon="139.78147779483">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89658.736"/>
-    <tag k="local_y" v="43162.6983"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="50" lat="35.62613705534" lon="139.78136750033">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89648.7938"/>
-    <tag k="local_y" v="43166.5202"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="52" lat="35.62599261007" lon="139.78173439621">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="52" lat="35.62599261055" lon="139.78173439587">
     <tag k="local_x" v="89681.8206"/>
     <tag k="local_y" v="43150.0873"/>
     <tag k="ele" v="42.6953"/>
   </node>
-  <node id="53" lat="35.62594607109" lon="139.7816697585">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="53" lat="35.62594607157" lon="139.78166975817">
     <tag k="local_x" v="89675.9032"/>
     <tag k="local_y" v="43144.9979"/>
     <tag k="ele" v="43.0341"/>
   </node>
-  <node id="54" lat="35.62592809997" lon="139.78163527775">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="54" lat="35.62592810045" lon="139.78163527741">
     <tag k="local_x" v="89672.756"/>
     <tag k="local_y" v="43143.0433"/>
     <tag k="ele" v="43.2036"/>
   </node>
-  <node id="55" lat="35.62582803315" lon="139.78132610156">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="55" lat="35.62582803363" lon="139.78132610122">
     <tag k="local_x" v="89644.6201"/>
     <tag k="local_y" v="43132.2912"/>
     <tag k="ele" v="43.082"/>
   </node>
-  <node id="56" lat="35.62587114519" lon="139.78139276872">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="56" lat="35.62587114567" lon="139.78139276838">
     <tag k="local_x" v="89650.7166"/>
     <tag k="local_y" v="43136.9982"/>
     <tag k="ele" v="43.082"/>
   </node>
-  <node id="57" lat="35.62629399043" lon="139.78145393722">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="57" lat="35.62629399091" lon="139.78145393688">
     <tag k="local_x" v="89656.837"/>
     <tag k="local_y" v="43183.8298"/>
     <tag k="ele" v="43.146"/>
   </node>
-  <node id="58" lat="35.62622712886" lon="139.78139867502">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="58" lat="35.62622712934" lon="139.78139867468">
     <tag k="local_x" v="89651.7407"/>
     <tag k="local_y" v="43176.4758"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="59" lat="35.62621724233" lon="139.78132009731">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="59" lat="35.62621724281" lon="139.78132009697">
     <tag k="local_x" v="89644.6113"/>
     <tag k="local_y" v="43175.4674"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="60" lat="35.62614660879" lon="139.78127609422">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="60" lat="35.62614660927" lon="139.78127609388">
     <tag k="local_x" v="89640.5294"/>
     <tag k="local_y" v="43167.6824"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="61" lat="35.62608300349" lon="139.78132222413">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="61" lat="35.62608300397" lon="139.78132222379">
     <tag k="local_x" v="89644.6194"/>
     <tag k="local_y" v="43160.5758"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="62" lat="35.6260384544" lon="139.78148585024">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="62" lat="35.62603845488" lon="139.7814858499">
     <tag k="local_x" v="89659.3758"/>
     <tag k="local_y" v="43155.451"/>
     <tag k="ele" v="42.6953"/>
   </node>
-  <node id="63" lat="35.62606547902" lon="139.78155052122">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="63" lat="35.6260654795" lon="139.78155052088">
     <tag k="local_x" v="89665.2694"/>
     <tag k="local_y" v="43158.3759"/>
     <tag k="ele" v="43.0341"/>
   </node>
-  <node id="64" lat="35.62626922989" lon="139.78148928741">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="64" lat="35.62626923036" lon="139.78148928707">
     <tag k="local_x" v="89660.0042"/>
     <tag k="local_y" v="43181.0438"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="65" lat="35.62623015969" lon="139.78127103183">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="65" lat="35.62623016017" lon="139.78127103149">
     <tag k="local_x" v="89640.1858"/>
     <tag k="local_y" v="43176.9552"/>
     <tag k="ele" v="43.146"/>
   </node>
-  <node id="66" lat="35.62624581419" lon="139.78121394092">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="66" lat="35.62624581467" lon="139.78121394058">
     <tag k="local_x" v="89635.0373"/>
     <tag k="local_y" v="43178.7556"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="67" lat="35.62615127802" lon="139.78158837441">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="67" lat="35.6261512785" lon="139.78158837407">
     <tag k="local_x" v="89668.8152"/>
     <tag k="local_y" v="43167.8499"/>
     <tag k="ele" v="43.2036"/>
   </node>
-  <node id="68" lat="35.62604935903" lon="139.7816838145">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="68" lat="35.62604935951" lon="139.78168381416">
     <tag k="local_x" v="89677.318"/>
     <tag k="local_y" v="43156.4384"/>
     <tag k="ele" v="43.2883"/>
   </node>
-  <node id="69" lat="35.62600127617" lon="139.78150986683">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="69" lat="35.62600127665" lon="139.78150986649">
     <tag k="local_x" v="89661.4996"/>
     <tag k="local_y" v="43151.3004"/>
     <tag k="ele" v="43.2965"/>
   </node>
-  <node id="70" lat="35.6259647948" lon="139.78144038238">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="70" lat="35.62596479528" lon="139.78144038204">
     <tag k="local_x" v="89655.1571"/>
     <tag k="local_y" v="43147.332"/>
     <tag k="ele" v="43.2583"/>
   </node>
-  <node id="456" lat="35.62610487649" lon="139.78092533649">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="456" lat="35.62610487697" lon="139.78092533615">
     <tag k="local_x" v="89608.7082"/>
     <tag k="local_y" v="43163.4473"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="457" lat="35.6261258356" lon="139.78093263883">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="457" lat="35.62612583608" lon="139.78093263849">
     <tag k="local_x" v="89609.3983"/>
     <tag k="local_y" v="43165.7638"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="458" lat="35.62608059045" lon="139.78092470694">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="458" lat="35.62608059093" lon="139.7809247066">
     <tag k="local_x" v="89608.6178"/>
     <tag k="local_y" v="43160.7543"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="459" lat="35.62616218539" lon="139.78097269974">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="459" lat="35.62616218587" lon="139.7809726994">
     <tag k="local_x" v="89613.0761"/>
     <tag k="local_y" v="43169.7506"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="460" lat="35.62615214929" lon="139.78095607386">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="460" lat="35.62615214977" lon="139.78095607352">
     <tag k="local_x" v="89611.5567"/>
     <tag k="local_y" v="43168.6561"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="461" lat="35.62617061032" lon="139.78099324264">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="461" lat="35.6261706108" lon="139.7809932423">
     <tag k="local_x" v="89614.948"/>
     <tag k="local_y" v="43170.662"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="462" lat="35.62617285382" lon="139.78105591004">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="462" lat="35.6261728543" lon="139.7810559097">
     <tag k="local_x" v="89620.6261"/>
     <tag k="local_y" v="43170.8405"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="463" lat="35.62617467409" lon="139.7810344353">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="463" lat="35.62617467457" lon="139.78103443496">
     <tag k="local_x" v="89618.6839"/>
     <tag k="local_y" v="43171.0665"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="464" lat="35.62616216635" lon="139.78108084874">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="464" lat="35.62616216683" lon="139.7810808484">
     <tag k="local_x" v="89622.8698"/>
     <tag k="local_y" v="43169.6271"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="465" lat="35.62589458674" lon="139.78131143946">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="465" lat="35.62589458722" lon="139.78131143912">
     <tag k="local_x" v="89643.3838"/>
     <tag k="local_y" v="43139.6895"/>
     <tag k="ele" v="43.147"/>
   </node>
-  <node id="466" lat="35.62589340195" lon="139.78129672545">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="466" lat="35.62589340243" lon="139.78129672511">
     <tag k="local_x" v="89642.0497"/>
     <tag k="local_y" v="43139.5746"/>
     <tag k="ele" v="43.1475"/>
   </node>
-  <node id="467" lat="35.62590209531" lon="139.78132081334">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="467" lat="35.62590209579" lon="139.781320813">
     <tag k="local_x" v="89644.243"/>
     <tag k="local_y" v="43140.5118"/>
     <tag k="ele" v="43.1465"/>
   </node>
-  <node id="468" lat="35.62618977544" lon="139.78107344072">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="468" lat="35.62618977592" lon="139.78107344038">
     <tag k="local_x" v="89622.2369"/>
     <tag k="local_y" v="43172.6977"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="469" lat="35.62619486772" lon="139.78104939747">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="469" lat="35.6261948682" lon="139.78104939713">
     <tag k="local_x" v="89620.0666"/>
     <tag k="local_y" v="43173.2895"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="470" lat="35.62618599624" lon="139.78109760979">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="470" lat="35.62618599672" lon="139.78109760945">
     <tag k="local_x" v="89624.4204"/>
     <tag k="local_y" v="43172.2514"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="471" lat="35.62621325078" lon="139.78101293372">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89616.7898"/>
-    <tag k="local_y" v="43175.3694"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="472" lat="35.6262049055" lon="139.78102333674">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89617.7204"/>
-    <tag k="local_y" v="43174.4321"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="473" lat="35.62622731894" lon="139.78100213794">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="473" lat="35.62622731942" lon="139.7810021376">
     <tag k="local_x" v="89615.8315"/>
     <tag k="local_y" v="43176.9419"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="474" lat="35.62627327103" lon="139.78099359891">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="474" lat="35.62627327151" lon="139.78099359857">
     <tag k="local_x" v="89615.1214"/>
     <tag k="local_y" v="43182.0483"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="475" lat="35.62625139033" lon="139.78099492052">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="475" lat="35.62625139081" lon="139.78099492018">
     <tag k="local_x" v="89615.211"/>
     <tag k="local_y" v="43179.6199"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="476" lat="35.62629272104" lon="139.78099664074">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="476" lat="35.62629272152" lon="139.7809966404">
     <tag k="local_x" v="89615.4236"/>
     <tag k="local_y" v="43184.2022"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="477" lat="35.62634303503" lon="139.78105893297">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="477" lat="35.62634303551" lon="139.78105893263">
     <tag k="local_x" v="89621.1338"/>
     <tag k="local_y" v="43189.7129"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="478" lat="35.62632540533" lon="139.78103076784">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="478" lat="35.62632540581" lon="139.7810307675">
     <tag k="local_x" v="89618.559"/>
     <tag k="local_y" v="43187.7891"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="479" lat="35.62635742811" lon="139.78108398792">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="479" lat="35.62635742859" lon="139.78108398758">
     <tag k="local_x" v="89623.4225"/>
     <tag k="local_y" v="43191.2812"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="480" lat="35.62633769733" lon="139.78123238338">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="480" lat="35.62633769781" lon="139.78123238304">
     <tag k="local_x" v="89636.8337"/>
     <tag k="local_y" v="43188.9262"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="481" lat="35.62637130397" lon="139.78117144204">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="481" lat="35.62637130445" lon="139.7811714417">
     <tag k="local_x" v="89631.3612"/>
     <tag k="local_y" v="43192.7221"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="482" lat="35.62629412885" lon="139.78127049047">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89640.2247"/>
-    <tag k="local_y" v="43184.051"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="483" lat="35.62637397917" lon="139.78113671186">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="483" lat="35.62637397965" lon="139.78113671152">
     <tag k="local_x" v="89628.2198"/>
     <tag k="local_y" v="43193.0578"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="484" lat="35.62636134481" lon="139.78120117774">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="484" lat="35.62636134529" lon="139.7812011774">
     <tag k="local_x" v="89634.0403"/>
     <tag k="local_y" v="43191.5841"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="485" lat="35.62631338556" lon="139.7812530025">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="485" lat="35.62631338604" lon="139.78125300216">
     <tag k="local_x" v="89638.6675"/>
     <tag k="local_y" v="43186.2065"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="486" lat="35.62629030041" lon="139.78128783703">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="486" lat="35.62629030089" lon="139.78128783669">
     <tag k="local_x" v="89641.7903"/>
     <tag k="local_y" v="43183.6069"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="487" lat="35.62630095027" lon="139.78132636791">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="487" lat="35.62630095075" lon="139.78132636757">
     <tag k="local_x" v="89645.2942"/>
     <tag k="local_y" v="43184.7449"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="488" lat="35.62635136727" lon="139.78141650629">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="488" lat="35.62635136775" lon="139.78141650595">
     <tag k="local_x" v="89653.5262"/>
     <tag k="local_y" v="43190.2358"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="489" lat="35.62636526739" lon="139.78144328152">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="489" lat="35.62636526787" lon="139.78144328118">
     <tag k="local_x" v="89655.97"/>
     <tag k="local_y" v="43191.7475"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="490" lat="35.62630762663" lon="139.78133555902">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89646.1357"/>
-    <tag k="local_y" v="43185.4751"/>
+  <node id="490" lat="35.62630718755" lon="139.78133666962">
+    <tag k="local_x" v="89646.2357"/>
+    <tag k="local_y" v="43185.4251"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="491" lat="35.62632892198" lon="139.78155622243">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="491" lat="35.62632892246" lon="139.78155622209">
     <tag k="local_x" v="89666.1477"/>
     <tag k="local_y" v="43187.5895"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="492" lat="35.62636049989" lon="139.7815295643">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="492" lat="35.62636050037" lon="139.78152956396">
     <tag k="local_x" v="89663.777"/>
     <tag k="local_y" v="43191.1219"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="493" lat="35.6262905032" lon="139.78158541263">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="493" lat="35.62629050368" lon="139.78158541229">
     <tag k="local_x" v="89668.7383"/>
     <tag k="local_y" v="43183.2955"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="494" lat="35.62622797316" lon="139.78156377805">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="494" lat="35.62622797364" lon="139.78156377771">
     <tag k="local_x" v="89666.6932"/>
     <tag k="local_y" v="43176.3842"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="495" lat="35.62624808879" lon="139.78158315752">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="495" lat="35.62624808927" lon="139.78158315718">
     <tag k="local_x" v="89668.4758"/>
     <tag k="local_y" v="43178.5936"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="496" lat="35.62621574091" lon="139.78154412437">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="496" lat="35.62621574139" lon="139.78154412403">
     <tag k="local_x" v="89664.8966"/>
     <tag k="local_y" v="43175.0495"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="497" lat="35.62617381838" lon="139.78144806968">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="497" lat="35.62617381886" lon="139.78144806934">
     <tag k="local_x" v="89656.1405"/>
     <tag k="local_y" v="43170.5074"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="498" lat="35.62616981784" lon="139.78140197197">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="498" lat="35.62616981832" lon="139.78140197163">
     <tag k="local_x" v="89651.9605"/>
     <tag k="local_y" v="43170.1154"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="499" lat="35.62618825584" lon="139.78148803602">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="499" lat="35.62618825632" lon="139.78148803568">
     <tag k="local_x" v="89659.7796"/>
     <tag k="local_y" v="43172.0639"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="500" lat="35.6261536315" lon="139.7813608694">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="500" lat="35.62615363198" lon="139.78136086906">
     <tag k="local_x" v="89648.2161"/>
     <tag k="local_y" v="43168.3662"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="501" lat="35.62615870043" lon="139.78136276249">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="501" lat="35.62615870091" lon="139.78136276215">
     <tag k="local_x" v="89648.3945"/>
     <tag k="local_y" v="43168.9263"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="502" lat="35.62614134473" lon="139.78136336711">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="502" lat="35.62614134521" lon="139.78136336677">
     <tag k="local_x" v="89648.4254"/>
     <tag k="local_y" v="43167.0006"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="503" lat="35.62611999679" lon="139.7814242138">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="503" lat="35.62611999727" lon="139.78142421346">
     <tag k="local_x" v="89653.9062"/>
     <tag k="local_y" v="43164.5645"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="504" lat="35.62613331133" lon="139.78138392572">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="504" lat="35.62613331181" lon="139.78138392538">
     <tag k="local_x" v="89650.2761"/>
     <tag k="local_y" v="43166.0865"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="505" lat="35.62610934837" lon="139.78145997146">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="505" lat="35.62610934885" lon="139.78145997113">
     <tag k="local_x" v="89657.1297"/>
     <tag k="local_y" v="43163.3433"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="506" lat="35.62611614747" lon="139.78149591489">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89660.394"/>
-    <tag k="local_y" v="43164.0571"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="507" lat="35.62610866259" lon="139.78149101952">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89659.9404"/>
-    <tag k="local_y" v="43163.2324"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="508" lat="35.62612606541" lon="139.78149302359">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="508" lat="35.62612606589" lon="139.78149302326">
     <tag k="local_x" v="89660.1458"/>
     <tag k="local_y" v="43165.1604"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="509" lat="35.62619696364" lon="139.78153432292">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="509" lat="35.62619696412" lon="139.78153432258">
     <tag k="local_x" v="89663.9832"/>
     <tag k="local_y" v="43172.9778"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="510" lat="35.62617473666" lon="139.78149356927">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="510" lat="35.62617473714" lon="139.78149356893">
     <tag k="local_x" v="89660.2621"/>
     <tag k="local_y" v="43170.5582"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="511" lat="35.62621169069" lon="139.78156548607">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="511" lat="35.62621169117" lon="139.78156548573">
     <tag k="local_x" v="89666.8255"/>
     <tag k="local_y" v="43174.5763"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="512" lat="35.62614233015" lon="139.78170696391">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="512" lat="35.62614233063" lon="139.78170696357">
     <tag k="local_x" v="89679.5421"/>
     <tag k="local_y" v="43166.7244"/>
     <tag k="ele" v="42.5828"/>
   </node>
-  <node id="513" lat="35.62617934074" lon="139.78167635301">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="513" lat="35.62617934122" lon="139.78167635267">
     <tag k="local_x" v="89676.8209"/>
     <tag k="local_y" v="43170.8638"/>
     <tag k="ele" v="42.8654"/>
   </node>
-  <node id="514" lat="35.62612709632" lon="139.78171786337">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="514" lat="35.6261270968" lon="139.78171786303">
     <tag k="local_x" v="89680.5082"/>
     <tag k="local_y" v="43165.0225"/>
     <tag k="ele" v="42.3002"/>
   </node>
-  <node id="515" lat="35.62620528603" lon="139.78165205634">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="515" lat="35.62620528651" lon="139.781652056">
     <tag k="local_x" v="89674.6563"/>
     <tag k="local_y" v="43173.7688"/>
     <tag k="ele" v="43.0067"/>
   </node>
-  <node id="516" lat="35.62611488914" lon="139.78173259952">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="516" lat="35.62611488962" lon="139.78173259918">
     <tag k="local_x" v="89681.8259"/>
     <tag k="local_y" v="43163.652"/>
     <tag k="ele" v="42.1589"/>
   </node>
-  <node id="517" lat="35.62615928797" lon="139.78169313847">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="517" lat="35.62615928845" lon="139.78169313813">
     <tag k="local_x" v="89678.3134"/>
     <tag k="local_y" v="43168.6208"/>
     <tag k="ele" v="42.7241"/>
   </node>
-  <node id="518" lat="35.62602808359" lon="139.78174765582">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="518" lat="35.62602808407" lon="139.78174765548">
     <tag k="local_x" v="89683.0701"/>
     <tag k="local_y" v="43154.007"/>
     <tag k="ele" v="42.3565"/>
   </node>
-  <node id="519" lat="35.62606016126" lon="139.78175552071">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="519" lat="35.62606016174" lon="139.78175552037">
     <tag k="local_x" v="89683.8264"/>
     <tag k="local_y" v="43157.5561"/>
     <tag k="ele" v="42.1871"/>
   </node>
-  <node id="520" lat="35.62601214587" lon="139.78174529818">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="520" lat="35.62601214635" lon="139.78174529784">
     <tag k="local_x" v="89682.8347"/>
     <tag k="local_y" v="43152.2419"/>
     <tag k="ele" v="42.5259"/>
   </node>
-  <node id="521" lat="35.62595597056" lon="139.78168652454">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="521" lat="35.62595597104" lon="139.7816865242">
     <tag k="local_x" v="89677.4351"/>
     <tag k="local_y" v="43146.0771"/>
     <tag k="ele" v="42.8647"/>
   </node>
-  <node id="522" lat="35.62597068569" lon="139.78171517562">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="522" lat="35.62597068617" lon="139.78171517528">
     <tag k="local_x" v="89680.0499"/>
     <tag k="local_y" v="43147.6771"/>
     <tag k="ele" v="42.78"/>
   </node>
-  <node id="523" lat="35.62593535099" lon="139.78164896331">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="523" lat="35.62593535147" lon="139.78164896297">
     <tag k="local_x" v="89674.0053"/>
     <tag k="local_y" v="43143.8322"/>
     <tag k="ele" v="43.1189"/>
   </node>
-  <node id="524" lat="35.62592840415" lon="139.78158218669">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="524" lat="35.62592840463" lon="139.78158218635">
     <tag k="local_x" v="89667.9486"/>
     <tag k="local_y" v="43143.1366"/>
     <tag k="ele" v="43.2883"/>
   </node>
-  <node id="525" lat="35.62593198025" lon="139.78155165582">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="525" lat="35.62593198073" lon="139.78155165548">
     <tag k="local_x" v="89665.1887"/>
     <tag k="local_y" v="43143.5675"/>
     <tag k="ele" v="43.3307"/>
   </node>
-  <node id="526" lat="35.62592556703" lon="139.78161857111">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="526" lat="35.62592556751" lon="139.78161857077">
     <tag k="local_x" v="89671.2396"/>
     <tag k="local_y" v="43142.7811"/>
     <tag k="ele" v="43.246"/>
   </node>
-  <node id="527" lat="35.62593445017" lon="139.78150838526">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89661.2736"/>
-    <tag k="local_y" v="43143.89"/>
-    <tag k="ele" v="43.2965"/>
-  </node>
-  <node id="528" lat="35.62592784057" lon="139.7814980381">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89660.3275"/>
-    <tag k="local_y" v="43143.1685"/>
-    <tag k="ele" v="43.2583"/>
-  </node>
-  <node id="529" lat="35.62593564514" lon="139.78152072164">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89662.3924"/>
-    <tag k="local_y" v="43144.0087"/>
-    <tag k="ele" v="43.3348"/>
-  </node>
-  <node id="530" lat="35.62585806747" lon="139.78148712778">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="530" lat="35.62585806795" lon="139.78148712744">
     <tag k="local_x" v="89659.2436"/>
     <tag k="local_y" v="43135.4418"/>
     <tag k="ele" v="43.2185"/>
   </node>
-  <node id="531" lat="35.62583266284" lon="139.78149419078">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="531" lat="35.62583266332" lon="139.78149419044">
     <tag k="local_x" v="89659.8483"/>
     <tag k="local_y" v="43132.6161"/>
     <tag k="ele" v="43.2177"/>
   </node>
-  <node id="532" lat="35.62588970941" lon="139.78148551685">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="532" lat="35.62588970989" lon="139.78148551651">
     <tag k="local_x" v="89659.1412"/>
     <tag k="local_y" v="43138.9532"/>
     <tag k="ele" v="43.2193"/>
   </node>
-  <node id="533" lat="35.62610169534" lon="139.78101483596">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="533" lat="35.62610169582" lon="139.78101483562">
     <tag k="local_x" v="89616.8087"/>
     <tag k="local_y" v="43162.994"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="534" lat="35.62609184059" lon="139.78100828929">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="534" lat="35.62609184107" lon="139.78100828895">
     <tag k="local_x" v="89616.2023"/>
     <tag k="local_y" v="43161.9083"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="535" lat="35.62610538964" lon="139.78102486404">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="535" lat="35.62610539012" lon="139.7810248637">
     <tag k="local_x" v="89617.7219"/>
     <tag k="local_y" v="43163.3925"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="536" lat="35.62582675775" lon="139.7812859445">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="536" lat="35.62582675823" lon="139.78128594416">
     <tag k="local_x" v="89640.9818"/>
     <tag k="local_y" v="43132.1948"/>
     <tag k="ele" v="43.115"/>
   </node>
-  <node id="537" lat="35.62583467898" lon="139.78125973715">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="537" lat="35.62583467946" lon="139.78125973681">
     <tag k="local_x" v="89638.6194"/>
     <tag k="local_y" v="43133.1028"/>
     <tag k="ele" v="43.1315"/>
   </node>
-  <node id="538" lat="35.62582526144" lon="139.78130486889">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="538" lat="35.62582526192" lon="139.78130486855">
     <tag k="local_x" v="89642.6935"/>
     <tag k="local_y" v="43132.0076"/>
     <tag k="ele" v="43.0985"/>
   </node>
-  <node id="539" lat="35.62584618215" lon="139.78136977913">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="539" lat="35.62584618263" lon="139.78136977879">
     <tag k="local_x" v="89648.6004"/>
     <tag k="local_y" v="43134.2552"/>
     <tag k="ele" v="43.082"/>
   </node>
-  <node id="540" lat="35.62583314266" lon="139.78134599683">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="540" lat="35.62583314314" lon="139.78134599649">
     <tag k="local_x" v="89646.4288"/>
     <tag k="local_y" v="43132.8356"/>
     <tag k="ele" v="43.082"/>
   </node>
-  <node id="541" lat="35.62585672239" lon="139.78138232704">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="541" lat="35.62585672287" lon="139.7813823267">
     <tag k="local_x" v="89649.7512"/>
     <tag k="local_y" v="43135.4102"/>
     <tag k="ele" v="43.082"/>
   </node>
-  <node id="542" lat="35.62590971123" lon="139.78140077572">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="542" lat="35.62590971171" lon="139.78140077538">
     <tag k="local_x" v="89651.4947"/>
     <tag k="local_y" v="43141.2668"/>
     <tag k="ele" v="43.114"/>
   </node>
-  <node id="543" lat="35.62588805715" lon="139.78139856564">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="543" lat="35.62588805763" lon="139.7813985653">
     <tag k="local_x" v="89651.2648"/>
     <tag k="local_y" v="43138.8675"/>
     <tag k="ele" v="43.098"/>
   </node>
-  <node id="544" lat="35.62592045264" lon="139.78139845166">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="544" lat="35.62592045312" lon="139.78139845132">
     <tag k="local_x" v="89651.299"/>
     <tag k="local_y" v="43142.4608"/>
     <tag k="ele" v="43.13"/>
   </node>
-  <node id="545" lat="35.62622670921" lon="139.78111312513">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="545" lat="35.62622670969" lon="139.78111312479">
     <tag k="local_x" v="89625.8814"/>
     <tag k="local_y" v="43176.7497"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="546" lat="35.62623063039" lon="139.78109746229">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="546" lat="35.62623063087" lon="139.78109746195">
     <tag k="local_x" v="89624.4684"/>
     <tag k="local_y" v="43177.2022"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="547" lat="35.62622690032" lon="139.78113896213">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="547" lat="35.6262269008" lon="139.78113896179">
     <tag k="local_x" v="89628.2214"/>
     <tag k="local_y" v="43176.7419"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="548" lat="35.62627735602" lon="139.78109408839">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="548" lat="35.6262773565" lon="139.78109408805">
     <tag k="local_x" v="89624.2271"/>
     <tag k="local_y" v="43182.3886"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="549" lat="35.62625926653" lon="139.78108053532">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="549" lat="35.62625926701" lon="139.78108053498">
     <tag k="local_x" v="89622.9749"/>
     <tag k="local_y" v="43180.3974"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="550" lat="35.62629157993" lon="139.78112131468">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="550" lat="35.62629158041" lon="139.78112131434">
     <tag k="local_x" v="89626.7122"/>
     <tag k="local_y" v="43183.9357"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="551" lat="35.62627602675" lon="139.7811860081">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89632.5493"/>
-    <tag k="local_y" v="43182.138"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="552" lat="35.62629570426" lon="139.78117393238">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="552" lat="35.62629570474" lon="139.78117393204">
     <tag k="local_x" v="89631.4828"/>
     <tag k="local_y" v="43184.3341"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="553" lat="35.62626143978" lon="139.78119543029">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="553" lat="35.62626144026" lon="139.78119542995">
     <tag k="local_x" v="89633.3825"/>
     <tag k="local_y" v="43180.5095"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="554" lat="35.62623427165" lon="139.78124116298">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="554" lat="35.62623427213" lon="139.78124116265">
     <tag k="local_x" v="89637.4866"/>
     <tag k="local_y" v="43177.4448"/>
     <tag k="ele" v="43.147"/>
   </node>
-  <node id="555" lat="35.62624493634" lon="139.78136768952">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="555" lat="35.62624493682" lon="139.78136768918">
     <tag k="local_x" v="89648.9592"/>
     <tag k="local_y" v="43178.4857"/>
     <tag k="ele" v="43.146"/>
   </node>
-  <node id="556" lat="35.62623371157" lon="139.78131831463">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="556" lat="35.62623371205" lon="139.78131831429">
     <tag k="local_x" v="89644.4725"/>
     <tag k="local_y" v="43177.2961"/>
     <tag k="ele" v="43.146"/>
   </node>
-  <node id="557" lat="35.62626884744" lon="139.78141716894">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="557" lat="35.62626884792" lon="139.7814171686">
     <tag k="local_x" v="89653.4728"/>
     <tag k="local_y" v="43181.0823"/>
     <tag k="ele" v="43.146"/>
   </node>
-  <node id="558" lat="35.62629062625" lon="139.78148741232">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="558" lat="35.62629062673" lon="139.78148741198">
     <tag k="local_x" v="89659.8638"/>
     <tag k="local_y" v="43183.4191"/>
     <tag k="ele" v="43.147"/>
   </node>
-  <node id="559" lat="35.62629890748" lon="139.78147147571">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89658.432"/>
-    <tag k="local_y" v="43184.3555"/>
-    <tag k="ele" v="43.1465"/>
-  </node>
-  <node id="560" lat="35.62628051389" lon="139.78149131478">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89660.2033"/>
-    <tag k="local_y" v="43182.2931"/>
-    <tag k="ele" v="43.1475"/>
-  </node>
-  <node id="561" lat="35.62624752295" lon="139.78144691472">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="561" lat="35.62624752343" lon="139.78144691438">
     <tag k="local_x" v="89656.1372"/>
     <tag k="local_y" v="43178.6837"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="562" lat="35.62626084294" lon="139.78147721471">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="562" lat="35.62626084342" lon="139.78147721437">
     <tag k="local_x" v="89658.8994"/>
     <tag k="local_y" v="43180.1271"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="563" lat="35.62623607962" lon="139.78142690896">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="563" lat="35.6262360801" lon="139.78142690862">
     <tag k="local_x" v="89654.3098"/>
     <tag k="local_y" v="43177.4369"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="564" lat="35.6262233668" lon="139.78136100256">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="564" lat="35.62622336728" lon="139.78136100222">
     <tag k="local_x" v="89648.324"/>
     <tag k="local_y" v="43176.1008"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="565" lat="35.62622449888" lon="139.78137407207">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="565" lat="35.62622449936" lon="139.78137407173">
     <tag k="local_x" v="89649.5091"/>
     <tag k="local_y" v="43176.2117"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="566" lat="35.62622206921" lon="139.78134315849">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="566" lat="35.62622206969" lon="139.78134315815">
     <tag k="local_x" v="89646.7063"/>
     <tag k="local_y" v="43175.9769"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="567" lat="35.62618923946" lon="139.78128698126">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="567" lat="35.62618923994" lon="139.78128698092">
     <tag k="local_x" v="89641.5739"/>
     <tag k="local_y" v="43172.3986"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="568" lat="35.62620713936" lon="139.78130300528">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="568" lat="35.62620713984" lon="139.78130300494">
     <tag k="local_x" v="89643.0496"/>
     <tag k="local_y" v="43174.366"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="569" lat="35.62616691788" lon="139.78127832248">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="569" lat="35.62616691836" lon="139.78127832214">
     <tag k="local_x" v="89640.7591"/>
     <tag k="local_y" v="43169.9325"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="570" lat="35.62610682005" lon="139.78129249025">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="570" lat="35.62610682053" lon="139.78129248991">
     <tag k="local_x" v="89641.9595"/>
     <tag k="local_y" v="43163.2508"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="571" lat="35.62612185893" lon="139.78128255328">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="571" lat="35.6261218594" lon="139.78128255294">
     <tag k="local_x" v="89641.0803"/>
     <tag k="local_y" v="43164.93"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="572" lat="35.62609151435" lon="139.78130635142">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="572" lat="35.62609151483" lon="139.78130635108">
     <tag k="local_x" v="89643.1937"/>
     <tag k="local_y" v="43161.5376"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="573" lat="35.6260514235" lon="139.78141239307">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="573" lat="35.62605142398" lon="139.78141239273">
     <tag k="local_x" v="89652.7415"/>
     <tag k="local_y" v="43156.9719"/>
     <tag k="ele" v="42.9217"/>
   </node>
-  <node id="574" lat="35.62606619039" lon="139.78137218346">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="574" lat="35.62606619087" lon="139.78137218312">
     <tag k="local_x" v="89649.1205"/>
     <tag k="local_y" v="43158.6549"/>
     <tag k="ele" v="43.0349"/>
   </node>
-  <node id="575" lat="35.62604314268" lon="139.78144173763">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="575" lat="35.62604314316" lon="139.78144173729">
     <tag k="local_x" v="89655.3875"/>
     <tag k="local_y" v="43156.0205"/>
     <tag k="ele" v="42.8085"/>
   </node>
-  <node id="576" lat="35.6260469698" lon="139.78152033647">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="576" lat="35.62604697028" lon="139.78152033613">
     <tag k="local_x" v="89662.5105"/>
     <tag k="local_y" v="43156.3568"/>
     <tag k="ele" v="42.8647"/>
   </node>
-  <node id="577" lat="35.62609567994" lon="139.78157107494">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="577" lat="35.62609568042" lon="139.7815710746">
     <tag k="local_x" v="89667.1722"/>
     <tag k="local_y" v="43161.7026"/>
     <tag k="ele" v="43.1189"/>
   </node>
-  <node id="578" lat="35.62613117498" lon="139.78157121987">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="578" lat="35.62613117546" lon="139.78157121953">
     <tag k="local_x" v="89667.2341"/>
     <tag k="local_y" v="43165.6394"/>
     <tag k="ele" v="43.1612"/>
   </node>
-  <node id="579" lat="35.62613766874" lon="139.781619496">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="579" lat="35.62613766922" lon="139.78161949566">
     <tag k="local_x" v="89671.6148"/>
     <tag k="local_y" v="43166.3055"/>
     <tag k="ele" v="43.246"/>
   </node>
-  <node id="580" lat="35.62607820162" lon="139.78166250955">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="580" lat="35.6260782021" lon="139.78166250921">
     <tag k="local_x" v="89675.4283"/>
     <tag k="local_y" v="43159.6614"/>
     <tag k="ele" v="43.2672"/>
   </node>
-  <node id="581" lat="35.62610795878" lon="139.78163910143">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="581" lat="35.62610795926" lon="139.78163910109">
     <tag k="local_x" v="89673.3494"/>
     <tag k="local_y" v="43162.9882"/>
     <tag k="ele" v="43.2566"/>
   </node>
-  <node id="582" lat="35.62601529207" lon="139.78164872432">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="582" lat="35.62601529255" lon="139.78164872398">
     <tag k="local_x" v="89674.0935"/>
     <tag k="local_y" v="43152.6992"/>
     <tag k="ele" v="43.3307"/>
   </node>
-  <node id="583" lat="35.62600224657" lon="139.78162764085">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="583" lat="35.62600224705" lon="139.78162764051">
     <tag k="local_x" v="89672.1663"/>
     <tag k="local_y" v="43151.2759"/>
     <tag k="ele" v="43.3519"/>
   </node>
-  <node id="584" lat="35.62602739792" lon="139.78167255181">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="584" lat="35.6260273984" lon="139.78167255147">
     <tag k="local_x" v="89676.2679"/>
     <tag k="local_y" v="43154.0152"/>
     <tag k="ele" v="43.3095"/>
   </node>
-  <node id="585" lat="35.62599609034" lon="139.78155230075">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="585" lat="35.62599609082" lon="139.78155230041">
     <tag k="local_x" v="89665.3352"/>
     <tag k="local_y" v="43150.6776"/>
     <tag k="ele" v="43.3348"/>
   </node>
-  <node id="586" lat="35.62599219177" lon="139.78157662283">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="586" lat="35.62599219225" lon="139.78157662249">
     <tag k="local_x" v="89667.5324"/>
     <tag k="local_y" v="43150.2179"/>
     <tag k="ele" v="43.3539"/>
   </node>
-  <node id="587" lat="35.6259998423" lon="139.78153104411">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="587" lat="35.62599984277" lon="139.78153104377">
     <tag k="local_x" v="89663.4154"/>
     <tag k="local_y" v="43151.1176"/>
     <tag k="ele" v="43.3157"/>
   </node>
-  <node id="588" lat="35.6259850655" lon="139.78147045422">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="588" lat="35.62598506598" lon="139.78147045388">
     <tag k="local_x" v="89657.9082"/>
     <tag k="local_y" v="43149.5466"/>
     <tag k="ele" v="43.2774"/>
   </node>
-  <node id="589" lat="35.62597594413" lon="139.78145387295">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="589" lat="35.62597594461" lon="139.78145387261">
     <tag k="local_x" v="89656.3941"/>
     <tag k="local_y" v="43148.5535"/>
     <tag k="ele" v="43.2678"/>
   </node>
-  <node id="590" lat="35.62599284537" lon="139.78148597146">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="590" lat="35.62599284585" lon="139.78148597112">
     <tag k="local_x" v="89659.3241"/>
     <tag k="local_y" v="43150.3921"/>
     <tag k="ele" v="43.287"/>
   </node>
-  <node id="591" lat="35.62594828063" lon="139.78142881073">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="591" lat="35.6259482811" lon="139.78142881039">
     <tag k="local_x" v="89654.0865"/>
     <tag k="local_y" v="43145.5133"/>
     <tag k="ele" v="43.2391"/>
   </node>
-  <node id="592" lat="35.62577016837" lon="139.78140602291">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="592" lat="35.62577016885" lon="139.78140602257">
     <tag k="local_x" v="89651.7781"/>
     <tag k="local_y" v="43125.7834"/>
     <tag k="ele" v="43.115"/>
   </node>
-  <node id="593" lat="35.6258035663" lon="139.78142871222">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="593" lat="35.62580356678" lon="139.78142871188">
     <tag k="local_x" v="89653.8787"/>
     <tag k="local_y" v="43129.4623"/>
     <tag k="ele" v="43.1825"/>
   </node>
-  <node id="594" lat="35.62577936108" lon="139.78141521773">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="594" lat="35.62577936156" lon="139.78141521739">
     <tag k="local_x" v="89652.6234"/>
     <tag k="local_y" v="43126.7927"/>
     <tag k="ele" v="43.1315"/>
   </node>
-  <node id="997" lat="35.62615454364" lon="139.78109334109">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="997" lat="35.62615454412" lon="139.78109334075">
     <tag k="local_x" v="89623.9906"/>
     <tag k="local_y" v="43168.7676"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="998" lat="35.6261693209" lon="139.78106895649">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="998" lat="35.62616932138" lon="139.78106895615">
     <tag k="local_x" v="89621.8027"/>
     <tag k="local_y" v="43170.434"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="999" lat="35.62613230844" lon="139.78111415838">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="999" lat="35.62613230892" lon="139.78111415804">
     <tag k="local_x" v="89625.8452"/>
     <tag k="local_y" v="43166.278"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1000" lat="35.62613872271" lon="139.78110733712">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89625.2363"/>
-    <tag k="local_y" v="43166.9971"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="1001" lat="35.62612174229" lon="139.78112275316">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1001" lat="35.62612174277" lon="139.78112275282">
     <tag k="local_x" v="89626.609"/>
     <tag k="local_y" v="43165.0964"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1002" lat="35.62609993805" lon="139.78114063095">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1002" lat="35.62609993853" lon="139.78114063061">
     <tag k="local_x" v="89628.198"/>
     <tag k="local_y" v="43162.6579"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1003" lat="35.62607034896" lon="139.78116219479">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1003" lat="35.62607034944" lon="139.78116219445">
     <tag k="local_x" v="89630.1101"/>
     <tag k="local_y" v="43159.3518"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1004" lat="35.6260453872" lon="139.78118201651">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1004" lat="35.62604538768" lon="139.78118201617">
     <tag k="local_x" v="89631.8708"/>
     <tag k="local_y" v="43156.5609"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1005" lat="35.62603024948" lon="139.78119189536">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1005" lat="35.62603024996" lon="139.78119189502">
     <tag k="local_x" v="89632.7446"/>
     <tag k="local_y" v="43154.8708"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1006" lat="35.62600380177" lon="139.78120840694">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1006" lat="35.62600380225" lon="139.7812084066">
     <tag k="local_x" v="89634.2035"/>
     <tag k="local_y" v="43151.9188"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1007" lat="35.62598811084" lon="139.7812189457">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1007" lat="35.62598811132" lon="139.78121894536">
     <tag k="local_x" v="89635.1363"/>
     <tag k="local_y" v="43150.1666"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1008" lat="35.62596371998" lon="139.78123495562">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1008" lat="35.62596372046" lon="139.78123495528">
     <tag k="local_x" v="89636.5526"/>
     <tag k="local_y" v="43147.4433"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1009" lat="35.62594486798" lon="139.78124869171">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1009" lat="35.62594486846" lon="139.78124869137">
     <tag k="local_x" v="89637.7706"/>
     <tag k="local_y" v="43145.3369"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1010" lat="35.62592728853" lon="139.78126371593">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1010" lat="35.625927289" lon="139.78126371559">
     <tag k="local_x" v="89639.107"/>
     <tag k="local_y" v="43143.3702"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1011" lat="35.62591262411" lon="139.78127439479">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1011" lat="35.62591262459" lon="139.78127439445">
     <tag k="local_x" v="89640.0539"/>
     <tag k="local_y" v="43141.7317"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1012" lat="35.62592372111" lon="139.78131782274">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89644.0019"/>
-    <tag k="local_y" v="43142.9138"/>
-    <tag k="ele" v="43.147"/>
-  </node>
-  <node id="1013" lat="35.6259281143" lon="139.78131245338">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1013" lat="35.62592811478" lon="139.78131245304">
     <tag k="local_x" v="89643.5217"/>
     <tag k="local_y" v="43143.4071"/>
     <tag k="ele" v="43.1475"/>
   </node>
-  <node id="1014" lat="35.62589576437" lon="139.78129078067">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89641.5146"/>
-    <tag k="local_y" v="43139.8433"/>
-    <tag k="ele" v="43.1478"/>
-  </node>
-  <node id="1015" lat="35.62589262936" lon="139.78130475192">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89642.7755"/>
-    <tag k="local_y" v="43139.4799"/>
-    <tag k="ele" v="43.1473"/>
-  </node>
-  <node id="1016" lat="35.62589778544" lon="139.78131739811">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1016" lat="35.62589778592" lon="139.78131739777">
     <tag k="local_x" v="89643.9278"/>
     <tag k="local_y" v="43140.0376"/>
     <tag k="ele" v="43.1468"/>
   </node>
-  <node id="1017" lat="35.62590765654" lon="139.78132315611">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89644.4628"/>
-    <tag k="local_y" v="43141.126"/>
-    <tag k="ele" v="43.1463"/>
-  </node>
-  <node id="1018" lat="35.62591750813" lon="139.78132163841">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89644.3389"/>
-    <tag k="local_y" v="43142.2204"/>
-    <tag k="ele" v="43.1465"/>
-  </node>
-  <node id="1019" lat="35.62590575303" lon="139.78127937551">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1019" lat="35.62590575351" lon="139.78127937517">
     <tag k="local_x" v="89640.4955"/>
     <tag k="local_y" v="43140.964"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1020" lat="35.62596382421" lon="139.78128411042">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1020" lat="35.62596382469" lon="139.78128411008">
     <tag k="local_x" v="89641.0041"/>
     <tag k="local_y" v="43147.3997"/>
     <tag k="ele" v="43.1478"/>
   </node>
-  <node id="1021" lat="35.62598904598" lon="139.78126396567">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1021" lat="35.62598904646" lon="139.78126396533">
     <tag k="local_x" v="89639.2145"/>
     <tag k="local_y" v="43150.2198"/>
     <tag k="ele" v="43.1479"/>
   </node>
-  <node id="1022" lat="35.62600903039" lon="139.78124800386">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1022" lat="35.62600903087" lon="139.78124800352">
     <tag k="local_x" v="89637.7965"/>
     <tag k="local_y" v="43152.4543"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1023" lat="35.6260332439" lon="139.78122943472">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1023" lat="35.62603324438" lon="139.78122943438">
     <tag k="local_x" v="89636.1482"/>
     <tag k="local_y" v="43155.1608"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1024" lat="35.62606844023" lon="139.78120183823">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1024" lat="35.62606844071" lon="139.78120183789">
     <tag k="local_x" v="89633.6975"/>
     <tag k="local_y" v="43159.0956"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1025" lat="35.62608991004" lon="139.7811846789">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1025" lat="35.62608991052" lon="139.78118467856">
     <tag k="local_x" v="89632.1731"/>
     <tag k="local_y" v="43161.4962"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1026" lat="35.62612046583" lon="139.78116028341">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1026" lat="35.62612046631" lon="139.78116028307">
     <tag k="local_x" v="89630.0059"/>
     <tag k="local_y" v="43164.9127"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1027" lat="35.62613908711" lon="139.7811447751">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1027" lat="35.62613908759" lon="139.78114477477">
     <tag k="local_x" v="89628.6271"/>
     <tag k="local_y" v="43166.9955"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1028" lat="35.6261525597" lon="139.7811340149">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1028" lat="35.62615256018" lon="139.78113401456">
     <tag k="local_x" v="89627.6712"/>
     <tag k="local_y" v="43168.5019"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1029" lat="35.62616475043" lon="139.78112362973">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1029" lat="35.62616475091" lon="139.78112362939">
     <tag k="local_x" v="89626.7475"/>
     <tag k="local_y" v="43169.8657"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1030" lat="35.62618124318" lon="139.78110652934">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1030" lat="35.62618124366" lon="139.781106529">
     <tag k="local_x" v="89625.2216"/>
     <tag k="local_y" v="43171.7142"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1031" lat="35.62618829468" lon="139.78108757133">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89623.5145"/>
-    <tag k="local_y" v="43172.5176"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="1032" lat="35.62618435552" lon="139.78110208158">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89624.8231"/>
-    <tag k="local_y" v="43172.0644"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="1033" lat="35.62617779754" lon="139.78111207427">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89625.719"/>
-    <tag k="local_y" v="43171.3258"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="1034" lat="35.62618756135" lon="139.78109172568">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89623.8897"/>
-    <tag k="local_y" v="43172.4316"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="1035" lat="35.62618886445" lon="139.78108311358">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1035" lat="35.62618886493" lon="139.78108311324">
     <tag k="local_x" v="89623.1116"/>
     <tag k="local_y" v="43172.5858"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1036" lat="35.62619197894" lon="139.78106150435">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1036" lat="35.62619197942" lon="139.78106150401">
     <tag k="local_x" v="89621.159"/>
     <tag k="local_y" v="43172.9555"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1037" lat="35.62620259406" lon="139.78102816987">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1037" lat="35.62620259454" lon="139.78102816953">
     <tag k="local_x" v="89618.1549"/>
     <tag k="local_y" v="43174.1703"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1038" lat="35.62621923342" lon="139.78100774007">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1038" lat="35.6262192339" lon="139.78100773973">
     <tag k="local_x" v="89616.3277"/>
     <tag k="local_y" v="43176.0388"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1039" lat="35.62620853026" lon="139.78101767313">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1039" lat="35.62620853074" lon="139.78101767279">
     <tag k="local_x" v="89617.2125"/>
     <tag k="local_y" v="43174.8405"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1040" lat="35.6262317321" lon="139.78100203892">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89615.8286"/>
-    <tag k="local_y" v="43177.4315"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="1041" lat="35.62624509404" lon="139.78099852105">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89615.5284"/>
-    <tag k="local_y" v="43178.9175"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="1042" lat="35.62626785934" lon="139.78099240232">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89615.0056"/>
-    <tag k="local_y" v="43181.4494"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="1043" lat="35.62626284255" lon="139.78099200917">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1043" lat="35.62626284303" lon="139.78099200883">
     <tag k="local_x" v="89614.9631"/>
     <tag k="local_y" v="43180.8934"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1044" lat="35.62625692388" lon="139.78099265558">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89615.0135"/>
-    <tag k="local_y" v="43180.2362"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="1045" lat="35.62628253762" lon="139.780994589">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1045" lat="35.6262825381" lon="139.78099458866">
     <tag k="local_x" v="89615.2238"/>
     <tag k="local_y" v="43183.075"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1046" lat="35.62630076044" lon="139.78100162704">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1046" lat="35.62630076092" lon="139.7810016267">
     <tag k="local_x" v="89615.8862"/>
     <tag k="local_y" v="43185.0883"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1047" lat="35.62637185532" lon="139.78112168185">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1047" lat="35.6263718558" lon="139.78112168151">
     <tag k="local_x" v="89626.8558"/>
     <tag k="local_y" v="43192.8391"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1048" lat="35.62636400518" lon="139.7810982447">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1048" lat="35.62636400566" lon="139.78109824436">
     <tag k="local_x" v="89624.7226"/>
     <tag k="local_y" v="43191.9947"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1049" lat="35.6263726191" lon="139.78115671209">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1049" lat="35.62637261958" lon="139.78115671175">
     <tag k="local_x" v="89630.0291"/>
     <tag k="local_y" v="43192.8845"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1050" lat="35.62636721614" lon="139.78118587287">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1050" lat="35.62636721662" lon="139.78118587253">
     <tag k="local_x" v="89632.6624"/>
     <tag k="local_y" v="43192.2525"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1051" lat="35.62634983255" lon="139.78121971871">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1051" lat="35.62634983303" lon="139.78121971837">
     <tag k="local_x" v="89635.7035"/>
     <tag k="local_y" v="43190.2864"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1052" lat="35.62632683306" lon="139.78124172145">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1052" lat="35.62632683354" lon="139.78124172111">
     <tag k="local_x" v="89637.6644"/>
     <tag k="local_y" v="43187.7107"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1053" lat="35.62630538255" lon="139.78125865084">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89639.168"/>
-    <tag k="local_y" v="43185.3125"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="1054" lat="35.62629211233" lon="139.7812759585">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1054" lat="35.62629211281" lon="139.78127595816">
     <tag k="local_x" v="89640.7171"/>
     <tag k="local_y" v="43183.8212"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1055" lat="35.62629121297" lon="139.7812976545">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1055" lat="35.62629121345" lon="139.78129765416">
     <tag k="local_x" v="89642.6806"/>
     <tag k="local_y" v="43183.6971"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1056" lat="35.62629664846" lon="139.78131840184">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1056" lat="35.62629664894" lon="139.7813184015">
     <tag k="local_x" v="89644.5669"/>
     <tag k="local_y" v="43184.2767"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1057" lat="35.62629828861" lon="139.78126530794">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1057" lat="35.62629828909" lon="139.7812653076">
     <tag k="local_x" v="89639.7611"/>
     <tag k="local_y" v="43184.5182"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1058" lat="35.62631781965" lon="139.78135442316">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1058" lat="35.62631782013" lon="139.78135442282">
     <tag k="local_x" v="89647.858"/>
     <tag k="local_y" v="43186.5845"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1059" lat="35.62633765715" lon="139.78139113393">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1059" lat="35.62633765763" lon="139.78139113359">
     <tag k="local_x" v="89651.2097"/>
     <tag k="local_y" v="43188.7436"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1060" lat="35.62637302197" lon="139.78145549634">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1060" lat="35.62637302245" lon="139.781455496">
     <tag k="local_x" v="89657.0868"/>
     <tag k="local_y" v="43192.5939"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1061" lat="35.62637763091" lon="139.78147020596">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1061" lat="35.62637763139" lon="139.78147020562">
     <tag k="local_x" v="89658.4252"/>
     <tag k="local_y" v="43193.0886"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1062" lat="35.62637591745" lon="139.78150581268">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1062" lat="35.62637591793" lon="139.78150581234">
     <tag k="local_x" v="89661.6473"/>
     <tag k="local_y" v="43192.8586"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1063" lat="35.62637013727" lon="139.78151908098">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1063" lat="35.62637013775" lon="139.78151908064">
     <tag k="local_x" v="89662.8409"/>
     <tag k="local_y" v="43192.2026"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1064" lat="35.62634660645" lon="139.78154159414">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1064" lat="35.62634660693" lon="139.7815415938">
     <tag k="local_x" v="89664.8473"/>
     <tag k="local_y" v="43189.5674"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1065" lat="35.62630845927" lon="139.78157241014">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1065" lat="35.62630845975" lon="139.7815724098">
     <tag k="local_x" v="89667.5855"/>
     <tag k="local_y" v="43185.3017"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1066" lat="35.62627910241" lon="139.7815906465">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1066" lat="35.62627910289" lon="139.78159064616">
     <tag k="local_x" v="89669.1966"/>
     <tag k="local_y" v="43182.0251"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1067" lat="35.62625776145" lon="139.78158855087">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1067" lat="35.62625776193" lon="139.78158855053">
     <tag k="local_x" v="89668.9775"/>
     <tag k="local_y" v="43179.6604"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1068" lat="35.62623963117" lon="139.78157621964">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1068" lat="35.62623963165" lon="139.7815762193">
     <tag k="local_x" v="89667.8359"/>
     <tag k="local_y" v="43177.6633"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1069" lat="35.62622203273" lon="139.78155425222">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1069" lat="35.62622203321" lon="139.78155425188">
     <tag k="local_x" v="89665.8224"/>
     <tag k="local_y" v="43175.736"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1070" lat="35.62619738319" lon="139.78150708087">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1070" lat="35.62619738367" lon="139.78150708053">
     <tag k="local_x" v="89661.5168"/>
     <tag k="local_y" v="43173.0549"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1071" lat="35.62618043035" lon="139.78146889964">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1071" lat="35.62618043083" lon="139.7814688993">
     <tag k="local_x" v="89658.0359"/>
     <tag k="local_y" v="43171.2174"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1072" lat="35.62617081615" lon="139.78141714824">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1072" lat="35.62617081663" lon="139.7814171479">
     <tag k="local_x" v="89653.3362"/>
     <tag k="local_y" v="43170.2091"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1073" lat="35.62617256856" lon="139.78143173774">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1073" lat="35.62617256904" lon="139.7814317374">
     <tag k="local_x" v="89654.6598"/>
     <tag k="local_y" v="43170.3871"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1074" lat="35.62616777846" lon="139.78138370299">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1074" lat="35.62616777894" lon="139.78138370265">
     <tag k="local_x" v="89650.3033"/>
     <tag k="local_y" v="43169.9097"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1075" lat="35.62616315362" lon="139.78136724449">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89648.8065"/>
-    <tag k="local_y" v="43169.4152"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="1076" lat="35.6261458816" lon="139.78136168271">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89648.2791"/>
-    <tag k="local_y" v="43167.5057"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="1077" lat="35.62613511384" lon="139.78137405712">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1077" lat="35.62613511432" lon="139.78137405678">
     <tag k="local_x" v="89649.3849"/>
     <tag k="local_y" v="43166.2975"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1078" lat="35.62612627361" lon="139.78140442724">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1078" lat="35.62612627408" lon="139.7814044269">
     <tag k="local_x" v="89652.123"/>
     <tag k="local_y" v="43165.2829"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1079" lat="35.62611724504" lon="139.78143730359">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1079" lat="35.62611724552" lon="139.78143730325">
     <tag k="local_x" v="89655.0878"/>
     <tag k="local_y" v="43164.2446"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1080" lat="35.62611422391" lon="139.7814467589">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1080" lat="35.62611422439" lon="139.78144675856">
     <tag k="local_x" v="89655.9399"/>
     <tag k="local_y" v="43163.8989"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1081" lat="35.62610593497" lon="139.78146852723">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1081" lat="35.62610593545" lon="139.78146852689">
     <tag k="local_x" v="89657.8998"/>
     <tag k="local_y" v="43162.9551"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1082" lat="35.62610491556" lon="139.78148477653">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1082" lat="35.62610491604" lon="139.78148477619">
     <tag k="local_x" v="89659.3699"/>
     <tag k="local_y" v="43162.8238"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1083" lat="35.62611252594" lon="139.78149396671">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1083" lat="35.62611252642" lon="139.78149396637">
     <tag k="local_x" v="89660.2126"/>
     <tag k="local_y" v="43163.6576"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1084" lat="35.62612018884" lon="139.78149649514">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1084" lat="35.62612018932" lon="139.7814964948">
     <tag k="local_x" v="89660.4521"/>
     <tag k="local_y" v="43164.5047"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1085" lat="35.62612939853" lon="139.78148793976">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89659.69"/>
-    <tag k="local_y" v="43165.5358"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="1086" lat="35.62615823061" lon="139.78147549221">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1086" lat="35.62615823109" lon="139.78147549187">
     <tag k="local_x" v="89658.6024"/>
     <tag k="local_y" v="43168.7477"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1087" lat="35.62614781136" lon="139.78147624111">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1087" lat="35.62614781184" lon="139.78147624077">
     <tag k="local_x" v="89658.6559"/>
     <tag k="local_y" v="43167.5912"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1088" lat="35.62616582985" lon="139.78147912588">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1088" lat="35.62616583033" lon="139.78147912554">
     <tag k="local_x" v="89658.9419"/>
     <tag k="local_y" v="43169.5865"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1089" lat="35.62617076742" lon="139.78148746327">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1089" lat="35.6261707679" lon="139.78148746293">
     <tag k="local_x" v="89659.7037"/>
     <tag k="local_y" v="43170.1248"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1090" lat="35.62613875742" lon="139.78148094244">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1090" lat="35.6261387579" lon="139.7814809421">
     <tag k="local_x" v="89659.0692"/>
     <tag k="local_y" v="43166.5817"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1091" lat="35.62618777925" lon="139.78151748305">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1091" lat="35.62618777973" lon="139.78151748271">
     <tag k="local_x" v="89662.4456"/>
     <tag k="local_y" v="43171.978"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1092" lat="35.62620336763" lon="139.7815478745">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1092" lat="35.62620336811" lon="139.78154787416">
     <tag k="local_x" v="89665.2192"/>
     <tag k="local_y" v="43173.6729"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1093" lat="35.62621505474" lon="139.78157575994">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1093" lat="35.62621505522" lon="139.7815757596">
     <tag k="local_x" v="89667.7605"/>
     <tag k="local_y" v="43174.9379"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1094" lat="35.62621667112" lon="139.78158911474">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1094" lat="35.6262166716" lon="139.7815891144">
     <tag k="local_x" v="89668.9721"/>
     <tag k="local_y" v="43175.1022"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1095" lat="35.62621342644" lon="139.78162397826">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1095" lat="35.62621342692" lon="139.78162397792">
     <tag k="local_x" v="89672.1248"/>
     <tag k="local_y" v="43174.7032"/>
     <tag k="ele" v="43.0774"/>
   </node>
-  <node id="1096" lat="35.62620983151" lon="139.78163722882">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1096" lat="35.62620983199" lon="139.78163722848">
     <tag k="local_x" v="89673.3198"/>
     <tag k="local_y" v="43174.2896"/>
     <tag k="ele" v="43.0421"/>
   </node>
-  <node id="1097" lat="35.62619726761" lon="139.78166197839">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1097" lat="35.62619726809" lon="139.78166197805">
     <tag k="local_x" v="89675.5438"/>
     <tag k="local_y" v="43172.8683"/>
     <tag k="ele" v="42.9361"/>
   </node>
-  <node id="1098" lat="35.6261897369" lon="139.78166797289">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1098" lat="35.62618973738" lon="139.78166797255">
     <tag k="local_x" v="89676.0763"/>
     <tag k="local_y" v="43172.0263"/>
     <tag k="ele" v="42.9008"/>
   </node>
-  <node id="1099" lat="35.62612052199" lon="139.78172580011">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1099" lat="35.62612052247" lon="139.78172579977">
     <tag k="local_x" v="89681.2179"/>
     <tag k="local_y" v="43164.2844"/>
     <tag k="ele" v="42.2296"/>
   </node>
-  <node id="1100" lat="35.62613465639" lon="139.7817124537">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1100" lat="35.62613465687" lon="139.78171245336">
     <tag k="local_x" v="89680.0287"/>
     <tag k="local_y" v="43165.8671"/>
     <tag k="ele" v="42.4415"/>
   </node>
-  <node id="1101" lat="35.62610951909" lon="139.78173997799">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1101" lat="35.62610951957" lon="139.78173997765">
     <tag k="local_x" v="89682.4867"/>
     <tag k="local_y" v="43163.0481"/>
     <tag k="ele" v="42.0883"/>
   </node>
-  <node id="1102" lat="35.62610305885" lon="139.78174885383">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1102" lat="35.62610305933" lon="139.78174885349">
     <tag k="local_x" v="89683.2816"/>
     <tag k="local_y" v="43162.3216"/>
     <tag k="ele" v="42.0529"/>
   </node>
-  <node id="1103" lat="35.62607285603" lon="139.7817575267">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1103" lat="35.62607285651" lon="139.78175752636">
     <tag k="local_x" v="89684.0255"/>
     <tag k="local_y" v="43158.9619"/>
     <tag k="ele" v="42.1024"/>
   </node>
-  <node id="1104" lat="35.6260879283" lon="139.78175935749">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1104" lat="35.62608792878" lon="139.78175935715">
     <tag k="local_x" v="89684.212"/>
     <tag k="local_y" v="43160.6316"/>
     <tag k="ele" v="42.06"/>
   </node>
-  <node id="1105" lat="35.62604467537" lon="139.7817521944">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1105" lat="35.62604467585" lon="139.78175219406">
     <tag k="local_x" v="89683.5039"/>
     <tag k="local_y" v="43155.8422"/>
     <tag k="ele" v="42.2718"/>
   </node>
-  <node id="1106" lat="35.62600082003" lon="139.78173949041">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1106" lat="35.62600082051" lon="139.78173949007">
     <tag k="local_x" v="89682.2932"/>
     <tag k="local_y" v="43150.9922"/>
     <tag k="ele" v="42.6106"/>
   </node>
-  <node id="1107" lat="35.62598080866" lon="139.78172453307">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1107" lat="35.62598080913" lon="139.78172453273">
     <tag k="local_x" v="89680.9112"/>
     <tag k="local_y" v="43148.7894"/>
     <tag k="ele" v="42.7377"/>
   </node>
-  <node id="1108" lat="35.62596417238" lon="139.78170445263">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1108" lat="35.62596417286" lon="139.78170445229">
     <tag k="local_x" v="89679.0699"/>
     <tag k="local_y" v="43146.9667"/>
     <tag k="ele" v="42.8224"/>
   </node>
-  <node id="1109" lat="35.62593159418" lon="139.78164282207">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1109" lat="35.62593159466" lon="139.78164282173">
     <tag k="local_x" v="89673.444"/>
     <tag k="local_y" v="43143.4224"/>
     <tag k="ele" v="43.1612"/>
   </node>
-  <node id="1110" lat="35.62592604947" lon="139.78160200091">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1110" lat="35.62592604995" lon="139.78160200057">
     <tag k="local_x" v="89669.7397"/>
     <tag k="local_y" v="43142.8532"/>
     <tag k="ele" v="43.2672"/>
   </node>
-  <node id="1111" lat="35.62593164573" lon="139.78150200651">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1111" lat="35.62593164621" lon="139.78150200617">
     <tag k="local_x" v="89660.6921"/>
     <tag k="local_y" v="43143.5861"/>
     <tag k="ele" v="43.2774"/>
   </node>
-  <node id="1112" lat="35.62592457797" lon="139.78149449654">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1112" lat="35.62592457845" lon="139.7814944962">
     <tag k="local_x" v="89660.0023"/>
     <tag k="local_y" v="43142.8106"/>
     <tag k="ele" v="43.2391"/>
   </node>
-  <node id="1113" lat="35.62593519085" lon="139.78151369105">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1113" lat="35.62593519133" lon="139.78151369071">
     <tag k="local_x" v="89661.7551"/>
     <tag k="local_y" v="43143.9662"/>
     <tag k="ele" v="43.3157"/>
   </node>
-  <node id="1114" lat="35.62593466827" lon="139.78152887711">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1114" lat="35.62593466875" lon="139.78152887677">
     <tag k="local_x" v="89663.1296"/>
     <tag k="local_y" v="43143.8912"/>
     <tag k="ele" v="43.3539"/>
   </node>
-  <node id="1115" lat="35.62577998554" lon="139.78150154616">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1115" lat="35.62577998602" lon="139.78150154582">
     <tag k="local_x" v="89660.442"/>
     <tag k="local_y" v="43126.7651"/>
     <tag k="ele" v="43.1825"/>
   </node>
-  <node id="1116" lat="35.62570902891" lon="139.78144057222">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1116" lat="35.62570902939" lon="139.78144057188">
     <tag k="local_x" v="89654.8228"/>
     <tag k="local_y" v="43118.9633"/>
     <tag k="ele" v="43.115"/>
   </node>
-  <node id="1117" lat="35.62569215097" lon="139.78140730186">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1117" lat="35.62569215145" lon="139.78140730152">
     <tag k="local_x" v="89651.7867"/>
     <tag k="local_y" v="43117.1286"/>
     <tag k="ele" v="43.0985"/>
   </node>
-  <node id="1118" lat="35.625723892" lon="139.78146985145">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1118" lat="35.62572389248" lon="139.78146985111">
     <tag k="local_x" v="89657.4947"/>
     <tag k="local_y" v="43120.579"/>
     <tag k="ele" v="43.1315"/>
   </node>
-  <node id="1119" lat="35.62574157736" lon="139.78149354667">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1119" lat="35.62574157783" lon="139.78149354633">
     <tag k="local_x" v="89659.6648"/>
     <tag k="local_y" v="43122.514"/>
     <tag k="ele" v="43.1398"/>
   </node>
-  <node id="1120" lat="35.62570333715" lon="139.78142808878">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1120" lat="35.62570333763" lon="139.78142808844">
     <tag k="local_x" v="89653.6845"/>
     <tag k="local_y" v="43118.346"/>
     <tag k="ele" v="43.1068"/>
   </node>
-  <node id="1121" lat="35.62568288034" lon="139.7813940589">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89650.5747"/>
-    <tag k="local_y" v="43116.1152"/>
-    <tag k="ele" v="43.0903"/>
-  </node>
-  <node id="1122" lat="35.62571462881" lon="139.78145261977">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1122" lat="35.62571462929" lon="139.78145261943">
     <tag k="local_x" v="89655.9215"/>
     <tag k="local_y" v="43119.5709"/>
     <tag k="ele" v="43.1233"/>
   </node>
-  <node id="1123" lat="35.62569748596" lon="139.78141624492">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1123" lat="35.62569748644" lon="139.78141624458">
     <tag k="local_x" v="89652.6039"/>
     <tag k="local_y" v="43117.7103"/>
     <tag k="ele" v="43.1026"/>
   </node>
-  <node id="1124" lat="35.62575138163" lon="139.78149929465">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1124" lat="35.62575138211" lon="139.78149929431">
     <tag k="local_x" v="89660.1988"/>
     <tag k="local_y" v="43123.595"/>
     <tag k="ele" v="43.1439"/>
   </node>
-  <node id="1125" lat="35.62573205326" lon="139.78148376719">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1125" lat="35.62573205374" lon="139.78148376685">
     <tag k="local_x" v="89658.7661"/>
     <tag k="local_y" v="43121.4686"/>
     <tag k="ele" v="43.1357"/>
   </node>
-  <node id="1126" lat="35.62568535563" lon="139.78138412052">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1126" lat="35.62568535611" lon="139.78138412018">
     <tag k="local_x" v="89649.6781"/>
     <tag k="local_y" v="43116.4009"/>
     <tag k="ele" v="43.0862"/>
   </node>
-  <node id="1127" lat="35.62568748231" lon="139.7813997014">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1127" lat="35.62568748279" lon="139.78139970107">
     <tag k="local_x" v="89651.092"/>
     <tag k="local_y" v="43116.6193"/>
     <tag k="ele" v="43.0944"/>
   </node>
-  <node id="1128" lat="35.62568976225" lon="139.78135343137">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1128" lat="35.62568976273" lon="139.78135343103">
     <tag k="local_x" v="89646.905"/>
     <tag k="local_y" v="43116.9241"/>
     <tag k="ele" v="43.115"/>
   </node>
-  <node id="1129" lat="35.62570027275" lon="139.78129878647">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1129" lat="35.62570027323" lon="139.78129878613">
     <tag k="local_x" v="89641.9709"/>
     <tag k="local_y" v="43118.1512"/>
     <tag k="ele" v="43.1315"/>
   </node>
-  <node id="1130" lat="35.6257110087" lon="139.78123898123">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1130" lat="35.62571100918" lon="139.78123898089">
     <tag k="local_x" v="89636.5698"/>
     <tag k="local_y" v="43119.4091"/>
     <tag k="ele" v="43.1398"/>
   </node>
-  <node id="1131" lat="35.62570444003" lon="139.78128026659">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1131" lat="35.62570444051" lon="139.78128026625">
     <tag k="local_x" v="89640.2995"/>
     <tag k="local_y" v="43118.6342"/>
     <tag k="ele" v="43.1357"/>
   </node>
-  <node id="1132" lat="35.6256947078" lon="139.78133092102">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1132" lat="35.62569470828" lon="139.78133092068">
     <tag k="local_x" v="89644.8733"/>
     <tag k="local_y" v="43117.4979"/>
     <tag k="ele" v="43.1233"/>
   </node>
-  <node id="1133" lat="35.62570597878" lon="139.78126322104">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1133" lat="35.62570597926" lon="139.7812632207">
     <tag k="local_x" v="89638.758"/>
     <tag k="local_y" v="43118.824"/>
     <tag k="ele" v="43.1377"/>
   </node>
-  <node id="1134" lat="35.62571758704" lon="139.78121834542">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1134" lat="35.62571758752" lon="139.78121834508">
     <tag k="local_x" v="89634.7101"/>
     <tag k="local_y" v="43120.1619"/>
     <tag k="ele" v="43.1439"/>
   </node>
-  <node id="1135" lat="35.6257352267" lon="139.78119020389">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1135" lat="35.62573522718" lon="139.78119020355">
     <tag k="local_x" v="89632.1859"/>
     <tag k="local_y" v="43122.15"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1136" lat="35.62574718658" lon="139.78117776394">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1136" lat="35.62574718706" lon="139.7811777636">
     <tag k="local_x" v="89631.0758"/>
     <tag k="local_y" v="43123.4905"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1137" lat="35.62576355814" lon="139.78116525923">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1137" lat="35.62576355862" lon="139.78116525889">
     <tag k="local_x" v="89629.9659"/>
     <tag k="local_y" v="43125.3204"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1138" lat="35.62578276503" lon="139.78115060012">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1138" lat="35.62578276551" lon="139.78115059978">
     <tag k="local_x" v="89628.6648"/>
     <tag k="local_y" v="43127.4672"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1139" lat="35.62580609571" lon="139.7811320146">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1139" lat="35.62580609619" lon="139.78113201426">
     <tag k="local_x" v="89627.0138"/>
     <tag k="local_y" v="43130.0758"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1140" lat="35.62583175916" lon="139.78111070477">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1140" lat="35.62583175964" lon="139.78111070443">
     <tag k="local_x" v="89625.1193"/>
     <tag k="local_y" v="43132.9462"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1141" lat="35.62585641937" lon="139.78108879287">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1141" lat="35.62585641985" lon="139.78108879253">
     <tag k="local_x" v="89623.1689"/>
     <tag k="local_y" v="43135.706"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1142" lat="35.62587359053" lon="139.78107360477">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1142" lat="35.625873591" lon="139.78107360443">
     <tag k="local_x" v="89621.8171"/>
     <tag k="local_y" v="43137.6276"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1143" lat="35.62589437404" lon="139.78105981393">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1143" lat="35.62589437452" lon="139.78105981359">
     <tag k="local_x" v="89620.5968"/>
     <tag k="local_y" v="43139.9483"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1144" lat="35.62592797683" lon="139.78103511822">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1144" lat="35.62592797731" lon="139.78103511788">
     <tag k="local_x" v="89618.4066"/>
     <tag k="local_y" v="43143.7031"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1145" lat="35.62594668784" lon="139.7810181432">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1145" lat="35.62594668832" lon="139.78101814286">
     <tag k="local_x" v="89616.8951"/>
     <tag k="local_y" v="43145.7975"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1146" lat="35.62597318913" lon="139.78099712867">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1146" lat="35.62597318961" lon="139.78099712833">
     <tag k="local_x" v="89615.0285"/>
     <tag k="local_y" v="43148.7605"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1147" lat="35.62598724253" lon="139.7809850522">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1147" lat="35.62598724301" lon="139.78098505186">
     <tag k="local_x" v="89613.9542"/>
     <tag k="local_y" v="43150.3328"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1148" lat="35.62600034808" lon="139.78097419486">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1148" lat="35.62600034856" lon="139.78097419452">
     <tag k="local_x" v="89612.989"/>
     <tag k="local_y" v="43151.7986"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1149" lat="35.62601240418" lon="139.78096547585">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1149" lat="35.62601240466" lon="139.78096547551">
     <tag k="local_x" v="89612.216"/>
     <tag k="local_y" v="43153.1456"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1150" lat="35.62602080851" lon="139.78096037354">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1150" lat="35.62602080899" lon="139.7809603732">
     <tag k="local_x" v="89611.7655"/>
     <tag k="local_y" v="43154.0835"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1151" lat="35.62602986798" lon="139.78095336968">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1151" lat="35.62602986845" lon="139.78095336934">
     <tag k="local_x" v="89611.1437"/>
     <tag k="local_y" v="43155.0962"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1152" lat="35.6260444631" lon="139.78094181501">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1152" lat="35.62604446357" lon="139.78094181467">
     <tag k="local_x" v="89610.1174"/>
     <tag k="local_y" v="43156.728"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1153" lat="35.62605198672" lon="139.78093681662">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1153" lat="35.6260519872" lon="139.78093681628">
     <tag k="local_x" v="89609.6751"/>
     <tag k="local_y" v="43157.5681"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1154" lat="35.62590404059" lon="139.78148761502">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1154" lat="35.62590404107" lon="139.78148761468">
     <tag k="local_x" v="89659.3509"/>
     <tag k="local_y" v="43140.5404"/>
     <tag k="ele" v="43.2197"/>
   </node>
-  <node id="1155" lat="35.62587524003" lon="139.78148570992">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1155" lat="35.62587524051" lon="139.78148570958">
     <tag k="local_x" v="89659.1388"/>
     <tag k="local_y" v="43137.3481"/>
     <tag k="ele" v="43.2189"/>
   </node>
-  <node id="1156" lat="35.6258430397" lon="139.78149121192">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1156" lat="35.62584304018" lon="139.78149121158">
     <tag k="local_x" v="89659.5928"/>
     <tag k="local_y" v="43133.7704"/>
     <tag k="ele" v="43.2181"/>
   </node>
-  <node id="1157" lat="35.62581609866" lon="139.78149853123">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1157" lat="35.62581609914" lon="139.78149853089">
     <tag k="local_x" v="89660.2186"/>
     <tag k="local_y" v="43130.774"/>
     <tag k="ele" v="43.2173"/>
   </node>
-  <node id="1158" lat="35.62582909456" lon="139.78142852357">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1158" lat="35.62582909504" lon="139.78142852323">
     <tag k="local_x" v="89653.8967"/>
     <tag k="local_y" v="43132.294"/>
     <tag k="ele" v="43.2185"/>
   </node>
-  <node id="1159" lat="35.62584586329" lon="139.78142711404">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1159" lat="35.62584586377" lon="139.7814271137">
     <tag k="local_x" v="89653.7921"/>
     <tag k="local_y" v="43134.1555"/>
     <tag k="ele" v="43.2193"/>
   </node>
-  <node id="1160" lat="35.62586360131" lon="139.78142562243">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1160" lat="35.62586360179" lon="139.78142562209">
     <tag k="local_x" v="89653.6814"/>
     <tag k="local_y" v="43136.1246"/>
     <tag k="ele" v="43.2197"/>
   </node>
-  <node id="1161" lat="35.62587862336" lon="139.78142435976">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1161" lat="35.62587862384" lon="139.78142435942">
     <tag k="local_x" v="89653.5877"/>
     <tag k="local_y" v="43137.7922"/>
     <tag k="ele" v="43.2199"/>
   </node>
-  <node id="1162" lat="35.62589203834" lon="139.78142323191">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1162" lat="35.62589203882" lon="139.78142323157">
     <tag k="local_x" v="89653.504"/>
     <tag k="local_y" v="43139.2814"/>
     <tag k="ele" v="43.22"/>
   </node>
-  <node id="1163" lat="35.62591120505" lon="139.78142162034">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1163" lat="35.62591120553" lon="139.78142162">
     <tag k="local_x" v="89653.3844"/>
     <tag k="local_y" v="43141.4091"/>
     <tag k="ele" v="43.22"/>
   </node>
-  <node id="1164" lat="35.62576319377" lon="139.78139765133">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1164" lat="35.62576319425" lon="139.78139765099">
     <tag k="local_x" v="89651.0104"/>
     <tag k="local_y" v="43125.0192"/>
     <tag k="ele" v="43.0985"/>
   </node>
-  <node id="1165" lat="35.62578457165" lon="139.78142006146">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1165" lat="35.62578457213" lon="139.78142006112">
     <tag k="local_x" v="89653.0692"/>
     <tag k="local_y" v="43127.3652"/>
     <tag k="ele" v="43.1398"/>
   </node>
-  <node id="1166" lat="35.62580965617" lon="139.78142894666">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1166" lat="35.62580965665" lon="139.78142894632">
     <tag k="local_x" v="89653.9083"/>
     <tag k="local_y" v="43130.1375"/>
     <tag k="ele" v="43.1997"/>
   </node>
-  <node id="1167" lat="35.62579328693" lon="139.78142555321">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1167" lat="35.62579328741" lon="139.78142555288">
     <tag k="local_x" v="89653.5785"/>
     <tag k="local_y" v="43128.3257"/>
     <tag k="ele" v="43.1653"/>
   </node>
-  <node id="1168" lat="35.62575548801" lon="139.78136896248">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1168" lat="35.62575548849" lon="139.78136896214">
     <tag k="local_x" v="89648.4018"/>
     <tag k="local_y" v="43124.1967"/>
     <tag k="ele" v="43.115"/>
   </node>
-  <node id="1169" lat="35.62575899421" lon="139.78134926112">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1169" lat="35.62575899469" lon="139.78134926078">
     <tag k="local_x" v="89646.6225"/>
     <tag k="local_y" v="43124.6077"/>
     <tag k="ele" v="43.1315"/>
   </node>
-  <node id="1170" lat="35.62576788989" lon="139.78129737152">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1170" lat="35.62576789037" lon="139.78129737118">
     <tag k="local_x" v="89641.9357"/>
     <tag k="local_y" v="43125.6526"/>
     <tag k="ele" v="43.1398"/>
   </node>
-  <node id="1171" lat="35.62577198516" lon="139.78127583256">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1171" lat="35.62577198564" lon="139.78127583222">
     <tag k="local_x" v="89639.9908"/>
     <tag k="local_y" v="43126.131"/>
     <tag k="ele" v="43.1439"/>
   </node>
-  <node id="1172" lat="35.62576306496" lon="139.78132877379">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1172" lat="35.62576306544" lon="139.78132877345">
     <tag k="local_x" v="89644.7728"/>
     <tag k="local_y" v="43125.0822"/>
     <tag k="ele" v="43.1357"/>
   </node>
-  <node id="1173" lat="35.62578883975" lon="139.78124227438">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1173" lat="35.62578884023" lon="139.78124227404">
     <tag k="local_x" v="89636.975"/>
     <tag k="local_y" v="43128.0381"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1174" lat="35.6258057443" lon="139.78122853586">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1174" lat="35.62580574478" lon="139.78122853552">
     <tag k="local_x" v="89635.7541"/>
     <tag k="local_y" v="43129.9285"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1175" lat="35.62582337375" lon="139.78121426511">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1175" lat="35.62582337423" lon="139.78121426477">
     <tag k="local_x" v="89634.486"/>
     <tag k="local_y" v="43131.8999"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1176" lat="35.62584290114" lon="139.781197778">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1176" lat="35.62584290162" lon="139.78119777766">
     <tag k="local_x" v="89633.0198"/>
     <tag k="local_y" v="43134.0843"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1177" lat="35.62586328744" lon="139.78118197353">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1177" lat="35.62586328792" lon="139.78118197319">
     <tag k="local_x" v="89631.6166"/>
     <tag k="local_y" v="43136.3632"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1178" lat="35.62588854934" lon="139.7811619651">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1178" lat="35.62588854982" lon="139.78116196476">
     <tag k="local_x" v="89629.8394"/>
     <tag k="local_y" v="43139.1876"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1179" lat="35.62592389996" lon="139.78113358005">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1179" lat="35.62592390044" lon="139.78113357971">
     <tag k="local_x" v="89627.3175"/>
     <tag k="local_y" v="43143.1404"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1180" lat="35.62594616021" lon="139.78111523821">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1180" lat="35.62594616069" lon="139.78111523787">
     <tag k="local_x" v="89625.6871"/>
     <tag k="local_y" v="43145.63"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1181" lat="35.62596866132" lon="139.78109824654">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1181" lat="35.6259686618" lon="139.7810982462">
     <tag k="local_x" v="89624.1793"/>
     <tag k="local_y" v="43148.1448"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1182" lat="35.62599126976" lon="139.78107965535">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1182" lat="35.62599127024" lon="139.78107965501">
     <tag k="local_x" v="89622.5268"/>
     <tag k="local_y" v="43150.6733"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1183" lat="35.62601479059" lon="139.78106168746">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1183" lat="35.62601479107" lon="139.78106168712">
     <tag k="local_x" v="89620.932"/>
     <tag k="local_y" v="43153.3023"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1184" lat="35.62602882939" lon="139.78104994912">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1184" lat="35.62602882987" lon="139.78104994878">
     <tag k="local_x" v="89619.8883"/>
     <tag k="local_y" v="43154.8726"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1185" lat="35.62604767357" lon="139.78103526452">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1185" lat="35.62604767405" lon="139.78103526418">
     <tag k="local_x" v="89618.5844"/>
     <tag k="local_y" v="43156.9792"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1186" lat="35.62606425093" lon="139.78102126916">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1186" lat="35.62606425141" lon="139.78102126882">
     <tag k="local_x" v="89617.3398"/>
     <tag k="local_y" v="43158.8336"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1187" lat="35.62607229653" lon="139.78101528668">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1187" lat="35.62607229701" lon="139.78101528634">
     <tag k="local_x" v="89616.8091"/>
     <tag k="local_y" v="43159.7327"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1188" lat="35.62607800994" lon="139.78101083919">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89616.4142"/>
-    <tag k="local_y" v="43160.3714"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="1189" lat="35.62608789601" lon="139.78100720515">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89616.0987"/>
-    <tag k="local_y" v="43161.472"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="1190" lat="35.6260973653" lon="139.78101058622">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89616.4179"/>
-    <tag k="local_y" v="43162.5185"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="1191" lat="35.62610391389" lon="139.78102015687">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89617.2936"/>
-    <tag k="local_y" v="43163.2341"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="1192" lat="35.62610455053" lon="139.78103175085">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89618.3444"/>
-    <tag k="local_y" v="43163.2917"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="1193" lat="35.62609440772" lon="139.7810447596">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1193" lat="35.6260944082" lon="139.78104475926">
     <tag k="local_x" v="89619.5085"/>
     <tag k="local_y" v="43162.1521"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1194" lat="35.62608680442" lon="139.78104972607">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1194" lat="35.6260868049" lon="139.78104972573">
     <tag k="local_x" v="89619.9478"/>
     <tag k="local_y" v="43161.3032"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1195" lat="35.62606383733" lon="139.78106708705">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1195" lat="35.62606383781" lon="139.78106708671">
     <tag k="local_x" v="89621.4884"/>
     <tag k="local_y" v="43158.7363"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1196" lat="35.62604540604" lon="139.78108185703">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1196" lat="35.62604540652" lon="139.78108185669">
     <tag k="local_x" v="89622.8006"/>
     <tag k="local_y" v="43156.6754"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1197" lat="35.62603121604" lon="139.78109388919">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1197" lat="35.62603121652" lon="139.78109388885">
     <tag k="local_x" v="89623.8707"/>
     <tag k="local_y" v="43155.088"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1198" lat="35.62601327717" lon="139.7811083193">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1198" lat="35.62601327765" lon="139.78110831896">
     <tag k="local_x" v="89625.1528"/>
     <tag k="local_y" v="43153.0821"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1199" lat="35.62600086995" lon="139.78111833561">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1199" lat="35.62600087042" lon="139.78111833527">
     <tag k="local_x" v="89626.0428"/>
     <tag k="local_y" v="43151.6947"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1200" lat="35.62598275808" lon="139.78113206381">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1200" lat="35.62598275856" lon="139.78113206347">
     <tag k="local_x" v="89627.2611"/>
     <tag k="local_y" v="43149.6704"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1201" lat="35.62596716871" lon="139.78114417461">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1201" lat="35.62596716919" lon="139.78114417427">
     <tag k="local_x" v="89628.3364"/>
     <tag k="local_y" v="43147.9277"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1202" lat="35.62595347553" lon="139.78115451852">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1202" lat="35.62595347601" lon="139.78115451818">
     <tag k="local_x" v="89629.2543"/>
     <tag k="local_y" v="43146.3973"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1203" lat="35.62594255686" lon="139.78116338145">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1203" lat="35.62594255734" lon="139.78116338111">
     <tag k="local_x" v="89630.0419"/>
     <tag k="local_y" v="43145.1763"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1204" lat="35.6259249342" lon="139.78117814352">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1204" lat="35.62592493468" lon="139.78117814318">
     <tag k="local_x" v="89631.3545"/>
     <tag k="local_y" v="43143.2051"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1205" lat="35.62591272583" lon="139.78118607304">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1205" lat="35.62591272631" lon="139.7811860727">
     <tag k="local_x" v="89632.0558"/>
     <tag k="local_y" v="43141.8421"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1206" lat="35.62589656621" lon="139.78119965453">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1206" lat="35.62589656669" lon="139.78119965419">
     <tag k="local_x" v="89633.2635"/>
     <tag k="local_y" v="43140.0345"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1207" lat="35.62588571973" lon="139.78120879131">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1207" lat="35.62588572021" lon="139.78120879097">
     <tag k="local_x" v="89634.076"/>
     <tag k="local_y" v="43138.8212"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1208" lat="35.62586660552" lon="139.78122414581">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1208" lat="35.625866606" lon="139.78122414547">
     <tag k="local_x" v="89635.4402"/>
     <tag k="local_y" v="43136.6839"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1209" lat="35.62584102772" lon="139.78124928942">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1209" lat="35.6258410282" lon="139.78124928908">
     <tag k="local_x" v="89637.682"/>
     <tag k="local_y" v="43133.8187"/>
     <tag k="ele" v="43.1398"/>
   </node>
-  <node id="1210" lat="35.6258296558" lon="139.78127127675">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1210" lat="35.62582965628" lon="139.78127127641">
     <tag k="local_x" v="89639.6575"/>
     <tag k="local_y" v="43132.5327"/>
     <tag k="ele" v="43.1233"/>
   </node>
-  <node id="1211" lat="35.62594694933" lon="139.78138276872">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1211" lat="35.62594694981" lon="139.78138276838">
     <tag k="local_x" v="89649.9152"/>
     <tag k="local_y" v="43145.4173"/>
     <tag k="ele" v="43.147"/>
   </node>
-  <node id="1212" lat="35.62595718024" lon="139.78137383012">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1212" lat="35.62595718072" lon="139.78137382978">
     <tag k="local_x" v="89649.1198"/>
     <tag k="local_y" v="43146.5621"/>
     <tag k="ele" v="43.1475"/>
   </node>
-  <node id="1213" lat="35.62597288882" lon="139.78136280636">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1213" lat="35.6259728893" lon="139.78136280602">
     <tag k="local_x" v="89648.1431"/>
     <tag k="local_y" v="43148.3168"/>
     <tag k="ele" v="43.1478"/>
   </node>
-  <node id="1214" lat="35.62598614099" lon="139.78135253654">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1214" lat="35.62598614147" lon="139.7813525362">
     <tag k="local_x" v="89647.2313"/>
     <tag k="local_y" v="43149.7982"/>
     <tag k="ele" v="43.1479"/>
   </node>
-  <node id="1215" lat="35.62600094961" lon="139.78134113883">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1215" lat="35.62600095009" lon="139.78134113849">
     <tag k="local_x" v="89646.2195"/>
     <tag k="local_y" v="43151.4535"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1216" lat="35.62601651555" lon="139.78132991845">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1216" lat="35.62601651603" lon="139.78132991811">
     <tag k="local_x" v="89645.2248"/>
     <tag k="local_y" v="43153.1926"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1217" lat="35.62603421219" lon="139.78131373297">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1217" lat="35.62603421267" lon="139.78131373264">
     <tag k="local_x" v="89643.7834"/>
     <tag k="local_y" v="43155.1736"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1218" lat="35.62604707357" lon="139.78130297767">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1218" lat="35.62604707405" lon="139.78130297733">
     <tag k="local_x" v="89642.8271"/>
     <tag k="local_y" v="43156.6122"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1219" lat="35.62606626662" lon="139.7812880184">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1219" lat="35.6260662671" lon="139.78128801806">
     <tag k="local_x" v="89641.4988"/>
     <tag k="local_y" v="43158.7578"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1220" lat="35.62607893812" lon="139.78127729799">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1220" lat="35.6260789386" lon="139.78127729765">
     <tag k="local_x" v="89640.5454"/>
     <tag k="local_y" v="43160.1753"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1221" lat="35.62609924839" lon="139.78126066203">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1221" lat="35.62609924887" lon="139.78126066169">
     <tag k="local_x" v="89639.0668"/>
     <tag k="local_y" v="43162.4467"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1222" lat="35.62611555633" lon="139.78124730354">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1222" lat="35.62611555681" lon="139.7812473032">
     <tag k="local_x" v="89637.8795"/>
     <tag k="local_y" v="43164.2705"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1223" lat="35.62613189428" lon="139.7812337922">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1223" lat="35.62613189476" lon="139.78123379186">
     <tag k="local_x" v="89636.6784"/>
     <tag k="local_y" v="43166.0978"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1224" lat="35.62616227509" lon="139.78120858663">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1224" lat="35.62616227557" lon="139.78120858629">
     <tag k="local_x" v="89634.4376"/>
     <tag k="local_y" v="43169.4958"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1225" lat="35.62617074894" lon="139.78119877026">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1225" lat="35.62617074942" lon="139.78119876992">
     <tag k="local_x" v="89633.5603"/>
     <tag k="local_y" v="43170.4467"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1226" lat="35.62617664965" lon="139.78119305224">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1226" lat="35.62617665013" lon="139.7811930519">
     <tag k="local_x" v="89633.0506"/>
     <tag k="local_y" v="43171.1076"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1227" lat="35.62619673368" lon="139.78117660077">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1227" lat="35.62619673416" lon="139.78117660043">
     <tag k="local_x" v="89631.5884"/>
     <tag k="local_y" v="43173.3537"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1228" lat="35.62618696485" lon="139.78118389146">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1228" lat="35.62618696533" lon="139.78118389112">
     <tag k="local_x" v="89632.2352"/>
     <tag k="local_y" v="43172.262"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1229" lat="35.62621186491" lon="139.78116688211">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1229" lat="35.62621186539" lon="139.78116688177">
     <tag k="local_x" v="89630.7291"/>
     <tag k="local_y" v="43175.0429"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1230" lat="35.62620403447" lon="139.78117221091">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1230" lat="35.62620403495" lon="139.78117221057">
     <tag k="local_x" v="89631.2009"/>
     <tag k="local_y" v="43174.1684"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1231" lat="35.62622488215" lon="139.78114889916">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1231" lat="35.62622488263" lon="139.78114889882">
     <tag k="local_x" v="89629.1185"/>
     <tag k="local_y" v="43176.5069"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1232" lat="35.626227013" lon="139.78112862446">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1232" lat="35.62622701348" lon="139.78112862412">
     <tag k="local_x" v="89627.2854"/>
     <tag k="local_y" v="43176.766"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1233" lat="35.62622801195" lon="139.78110501217">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89625.1485"/>
-    <tag k="local_y" v="43176.9033"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="1234" lat="35.62623593576" lon="139.78108939899">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89623.7455"/>
-    <tag k="local_y" v="43177.7997"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="1235" lat="35.62624840117" lon="139.78108067707">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1235" lat="35.62624840164" lon="139.78108067673">
     <tag k="local_x" v="89622.9728"/>
     <tag k="local_y" v="43179.1921"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1236" lat="35.62626573925" lon="139.78108225249">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89623.1393"/>
-    <tag k="local_y" v="43181.1134"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="1237" lat="35.62627293802" lon="139.78108702629">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1237" lat="35.6262729385" lon="139.78108702595">
     <tag k="local_x" v="89623.5815"/>
     <tag k="local_y" v="43181.9065"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1238" lat="35.62628504641" lon="139.78110895548">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1238" lat="35.62628504689" lon="139.78110895514">
     <tag k="local_x" v="89625.584"/>
     <tag k="local_y" v="43183.2249"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1239" lat="35.62628157736" lon="139.78110256473">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1239" lat="35.62628157784" lon="139.78110256439">
     <tag k="local_x" v="89625.0005"/>
     <tag k="local_y" v="43182.8473"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1240" lat="35.62629626962" lon="139.78112858578">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1240" lat="35.6262962701" lon="139.78112858544">
     <tag k="local_x" v="89627.3771"/>
     <tag k="local_y" v="43184.4477"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1241" lat="35.62630008031" lon="139.78113345629">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89627.8234"/>
-    <tag k="local_y" v="43184.8649"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="1242" lat="35.62630284732" lon="139.78113844976">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1242" lat="35.6263028478" lon="139.78113844942">
     <tag k="local_x" v="89628.2794"/>
     <tag k="local_y" v="43185.1662"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1243" lat="35.62630559326" lon="139.78114938121">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1243" lat="35.62630559374" lon="139.78114938087">
     <tag k="local_x" v="89629.2731"/>
     <tag k="local_y" v="43185.4585"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1244" lat="35.6263052847" lon="139.78115630967">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89629.9001"/>
-    <tag k="local_y" v="43185.4165"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="1245" lat="35.62630382823" lon="139.78116268465">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1245" lat="35.62630382871" lon="139.78116268431">
     <tag k="local_x" v="89630.4754"/>
     <tag k="local_y" v="43185.2478"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1246" lat="35.62630057694" lon="139.78116881521">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89631.0261"/>
-    <tag k="local_y" v="43184.8803"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="1247" lat="35.62628962925" lon="139.78117766095">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89631.8121"/>
-    <tag k="local_y" v="43183.6561"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="1248" lat="35.6262833052" lon="139.78118190458">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1248" lat="35.62628330568" lon="139.78118190424">
     <tag k="local_x" v="89632.1877"/>
     <tag k="local_y" v="43182.9499"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1249" lat="35.62626941922" lon="139.78119021407">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1249" lat="35.6262694197" lon="139.78119021373">
     <tag k="local_x" v="89632.9211"/>
     <tag k="local_y" v="43181.4004"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1250" lat="35.62625272534" lon="139.78120338742">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1250" lat="35.62625272582" lon="139.78120338708">
     <tag k="local_x" v="89634.0911"/>
     <tag k="local_y" v="43179.534"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1251" lat="35.62624149349" lon="139.78122103959">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89635.6742"/>
-    <tag k="local_y" v="43178.2684"/>
-    <tag k="ele" v="43.1475"/>
-  </node>
-  <node id="1252" lat="35.62623728104" lon="139.78122841048">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1252" lat="35.62623728152" lon="139.78122841014">
     <tag k="local_x" v="89636.3359"/>
     <tag k="local_y" v="43177.7929"/>
     <tag k="ele" v="43.1473"/>
   </node>
-  <node id="1253" lat="35.62623122469" lon="139.78125456868">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1253" lat="35.62623122517" lon="139.78125456834">
     <tag k="local_x" v="89638.6964"/>
     <tag k="local_y" v="43177.0918"/>
     <tag k="ele" v="43.1465"/>
   </node>
-  <node id="1254" lat="35.62623024536" lon="139.7812863611">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1254" lat="35.62623024584" lon="139.78128636076">
     <tag k="local_x" v="89641.5741"/>
     <tag k="local_y" v="43176.9475"/>
     <tag k="ele" v="43.146"/>
   </node>
-  <node id="1255" lat="35.6262308918" lon="139.78130151069">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1255" lat="35.62623089228" lon="139.78130151035">
     <tag k="local_x" v="89642.9469"/>
     <tag k="local_y" v="43177.0022"/>
     <tag k="ele" v="43.146"/>
   </node>
-  <node id="1256" lat="35.62623631286" lon="139.78133321812">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1256" lat="35.62623631334" lon="139.78133321778">
     <tag k="local_x" v="89645.8257"/>
     <tag k="local_y" v="43177.5679"/>
     <tag k="ele" v="43.146"/>
   </node>
-  <node id="1257" lat="35.62624038799" lon="139.78135085991">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1257" lat="35.62624038846" lon="139.78135085957">
     <tag k="local_x" v="89647.4289"/>
     <tag k="local_y" v="43178.0001"/>
     <tag k="ele" v="43.146"/>
   </node>
-  <node id="1258" lat="35.62624847513" lon="139.78137776638">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1258" lat="35.62624847561" lon="139.78137776604">
     <tag k="local_x" v="89649.8766"/>
     <tag k="local_y" v="43178.8669"/>
     <tag k="ele" v="43.146"/>
   </node>
-  <node id="1259" lat="35.62625379598" lon="139.78139021356">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1259" lat="35.62625379646" lon="139.78139021322">
     <tag k="local_x" v="89651.0111"/>
     <tag k="local_y" v="43179.4431"/>
     <tag k="ele" v="43.146"/>
   </node>
-  <node id="1260" lat="35.62626064311" lon="139.781403987">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1260" lat="35.62626064359" lon="139.78140398667">
     <tag k="local_x" v="89652.2678"/>
     <tag k="local_y" v="43180.1871"/>
     <tag k="ele" v="43.146"/>
   </node>
-  <node id="1261" lat="35.62627642208" lon="139.78142888624">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1261" lat="35.62627642256" lon="139.7814288859">
     <tag k="local_x" v="89654.5443"/>
     <tag k="local_y" v="43181.9093"/>
     <tag k="ele" v="43.146"/>
   </node>
-  <node id="1262" lat="35.62628243567" lon="139.78143744362">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1262" lat="35.62628243615" lon="139.78143744328">
     <tag k="local_x" v="89655.3275"/>
     <tag k="local_y" v="43182.5667"/>
     <tag k="ele" v="43.146"/>
   </node>
-  <node id="1263" lat="35.62628797391" lon="139.78144482223">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1263" lat="35.62628797439" lon="139.78144482189">
     <tag k="local_x" v="89656.0033"/>
     <tag k="local_y" v="43183.1727"/>
     <tag k="ele" v="43.146"/>
   </node>
-  <node id="1264" lat="35.62629584381" lon="139.78145872261">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89657.2729"/>
-    <tag k="local_y" v="43184.03"/>
-    <tag k="ele" v="43.1463"/>
-  </node>
-  <node id="1265" lat="35.62629862464" lon="139.78146561854">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1265" lat="35.62629862511" lon="139.7814656182">
     <tag k="local_x" v="89657.9012"/>
     <tag k="local_y" v="43184.3307"/>
     <tag k="ele" v="43.1464"/>
   </node>
-  <node id="1266" lat="35.62629828239" lon="139.78147527947">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1266" lat="35.62629828287" lon="139.78147527913">
     <tag k="local_x" v="89658.7756"/>
     <tag k="local_y" v="43184.2819"/>
     <tag k="ele" v="43.1468"/>
   </node>
-  <node id="1267" lat="35.62629570319" lon="139.78148047224">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89659.2423"/>
-    <tag k="local_y" v="43183.99"/>
-    <tag k="ele" v="43.1469"/>
-  </node>
-  <node id="1268" lat="35.62628526018" lon="139.78149019038">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89660.108"/>
-    <tag k="local_y" v="43182.8208"/>
-    <tag k="ele" v="43.1473"/>
-  </node>
-  <node id="1269" lat="35.62627564131" lon="139.78149082775">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1269" lat="35.62627564179" lon="139.78149082741">
     <tag k="local_x" v="89660.1525"/>
     <tag k="local_y" v="43181.7532"/>
     <tag k="ele" v="43.1478"/>
   </node>
-  <node id="1270" lat="35.62626406066" lon="139.78148371752">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89659.4927"/>
-    <tag k="local_y" v="43180.4767"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="1271" lat="35.62625511037" lon="139.78146417305">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1271" lat="35.62625511084" lon="139.78146417271">
     <tag k="local_x" v="89657.7105"/>
     <tag k="local_y" v="43179.5059"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1272" lat="35.62625207335" lon="139.78145601552">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1272" lat="35.62625207383" lon="139.78145601518">
     <tag k="local_x" v="89656.9676"/>
     <tag k="local_y" v="43179.1782"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1273" lat="35.62624241715" lon="139.7814379891">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1273" lat="35.62624241762" lon="139.78143798876">
     <tag k="local_x" v="89655.3219"/>
     <tag k="local_y" v="43178.1274"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1274" lat="35.62623029474" lon="139.78141181637">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1274" lat="35.62623029522" lon="139.78141181603">
     <tag k="local_x" v="89652.9351"/>
     <tag k="local_y" v="43176.8122"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1275" lat="35.6262257283" lon="139.78138758402">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1275" lat="35.62622572878" lon="139.78138758368">
     <tag k="local_x" v="89650.7344"/>
     <tag k="local_y" v="43176.3329"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1276" lat="35.62622066522" lon="139.78133110572">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1276" lat="35.6262206657" lon="139.78133110538">
     <tag k="local_x" v="89645.6129"/>
     <tag k="local_y" v="43175.8347"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1277" lat="35.62621293293" lon="139.78131280718">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1277" lat="35.62621293341" lon="139.78131280684">
     <tag k="local_x" v="89643.9452"/>
     <tag k="local_y" v="43174.9976"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1278" lat="35.62613406314" lon="139.78127822262">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1278" lat="35.62613406361" lon="139.78127822228">
     <tag k="local_x" v="89640.7049"/>
     <tag k="local_y" v="43166.2885"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1279" lat="35.6261559343" lon="139.78127640322">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1279" lat="35.62615593478" lon="139.78127640288">
     <tag k="local_x" v="89640.5702"/>
     <tag k="local_y" v="43168.7164"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1280" lat="35.62609948686" lon="139.78129742057">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1280" lat="35.62609948734" lon="139.78129742023">
     <tag k="local_x" v="89642.3959"/>
     <tag k="local_y" v="43162.4319"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1281" lat="35.62611404641" lon="139.78128662403">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1281" lat="35.62611404689" lon="139.78128662369">
     <tag k="local_x" v="89641.4382"/>
     <tag k="local_y" v="43164.0589"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1282" lat="35.62603894032" lon="139.78146436709">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1282" lat="35.62603894079" lon="139.78146436675">
     <tag k="local_x" v="89657.431"/>
     <tag k="local_y" v="43155.529"/>
     <tag k="ele" v="42.7519"/>
   </node>
-  <node id="1283" lat="35.62604143082" lon="139.7815026352">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1283" lat="35.6260414313" lon="139.78150263486">
     <tag k="local_x" v="89660.8999"/>
     <tag k="local_y" v="43155.7623"/>
     <tag k="ele" v="42.78"/>
   </node>
-  <node id="1284" lat="35.62605442435" lon="139.78153640417">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1284" lat="35.62605442483" lon="139.78153640383">
     <tag k="local_x" v="89663.9758"/>
     <tag k="local_y" v="43157.1656"/>
     <tag k="ele" v="42.9494"/>
   </node>
-  <node id="1285" lat="35.62608164281" lon="139.7815650676">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1285" lat="35.62608164329" lon="139.78156506726">
     <tag k="local_x" v="89666.6089"/>
     <tag k="local_y" v="43160.1524"/>
     <tag k="ele" v="43.0765"/>
   </node>
-  <node id="1286" lat="35.62610306101" lon="139.78157381857">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1286" lat="35.62610306149" lon="139.78157381823">
     <tag k="local_x" v="89667.4308"/>
     <tag k="local_y" v="43162.5182"/>
     <tag k="ele" v="43.1401"/>
   </node>
-  <node id="1287" lat="35.62611746971" lon="139.78157466776">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1287" lat="35.62611747019" lon="139.78157466742">
     <tag k="local_x" v="89667.5275"/>
     <tag k="local_y" v="43164.1154"/>
     <tag k="ele" v="43.1507"/>
   </node>
-  <node id="1288" lat="35.62614247658" lon="139.78157231277">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89667.3486"/>
-    <tag k="local_y" v="43166.8917"/>
-    <tag k="ele" v="43.1824"/>
-  </node>
-  <node id="1289" lat="35.6261497307" lon="139.78160858833">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1289" lat="35.62614973118" lon="139.78160858799">
     <tag k="local_x" v="89670.6436"/>
     <tag k="local_y" v="43167.6556"/>
     <tag k="ele" v="43.2248"/>
   </node>
-  <node id="1290" lat="35.62613400462" lon="139.78157099915">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89667.218"/>
-    <tag k="local_y" v="43165.9535"/>
-    <tag k="ele" v="43.1718"/>
-  </node>
-  <node id="1291" lat="35.62614701124" lon="139.78157700667">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1291" lat="35.62614701172" lon="139.78157700633">
     <tag k="local_x" v="89667.7799"/>
     <tag k="local_y" v="43167.3894"/>
     <tag k="ele" v="43.193"/>
   </node>
-  <node id="1292" lat="35.62615224887" lon="139.78159869784">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1292" lat="35.62615224935" lon="139.7815986975">
     <tag k="local_x" v="89669.7514"/>
     <tag k="local_y" v="43167.946"/>
     <tag k="ele" v="43.2142"/>
   </node>
-  <node id="1293" lat="35.62614285791" lon="139.78161571796">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1293" lat="35.62614285839" lon="139.78161571762">
     <tag k="local_x" v="89671.2798"/>
     <tag k="local_y" v="43166.8853"/>
     <tag k="ele" v="43.2354"/>
   </node>
-  <node id="1294" lat="35.62615130755" lon="139.78160279239">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89670.1209"/>
-    <tag k="local_y" v="43167.837"/>
-    <tag k="ele" v="43.2195"/>
-  </node>
-  <node id="1295" lat="35.62614626323" lon="139.78161224527">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89670.97"/>
-    <tag k="local_y" v="43167.2669"/>
-    <tag k="ele" v="43.2301"/>
-  </node>
-  <node id="1296" lat="35.62613782269" lon="139.78157151985">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1296" lat="35.62613782317" lon="139.78157151951">
     <tag k="local_x" v="89667.2704"/>
     <tag k="local_y" v="43166.3764"/>
     <tag k="ele" v="43.1771"/>
   </node>
-  <node id="1297" lat="35.62614981155" lon="139.78158190798">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89668.2276"/>
-    <tag k="local_y" v="43167.6945"/>
-    <tag k="ele" v="43.1983"/>
-  </node>
-  <node id="1298" lat="35.62612333758" lon="139.78157300955">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1298" lat="35.62612333806" lon="139.78157300922">
     <tag k="local_x" v="89667.3854"/>
     <tag k="local_y" v="43164.7681"/>
     <tag k="ele" v="43.156"/>
   </node>
-  <node id="1299" lat="35.6261100518" lon="139.78157532472">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1299" lat="35.62611005228" lon="139.78157532438">
     <tag k="local_x" v="89667.5768"/>
     <tag k="local_y" v="43163.2919"/>
     <tag k="ele" v="43.1454"/>
   </node>
-  <node id="1300" lat="35.62613176702" lon="139.78162110613">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1300" lat="35.6261317675" lon="139.78162110579">
     <tag k="local_x" v="89671.7525"/>
     <tag k="local_y" v="43165.6491"/>
     <tag k="ele" v="43.2513"/>
   </node>
-  <node id="1301" lat="35.62612646888" lon="139.78162347014">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1301" lat="35.62612646936" lon="139.7816234698">
     <tag k="local_x" v="89671.9593"/>
     <tag k="local_y" v="43165.0588"/>
     <tag k="ele" v="43.254"/>
   </node>
-  <node id="1302" lat="35.62611784404" lon="139.78162968111">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1302" lat="35.62611784451" lon="139.78162968077">
     <tag k="local_x" v="89672.5099"/>
     <tag k="local_y" v="43164.0952"/>
     <tag k="ele" v="43.2553"/>
   </node>
-  <node id="1303" lat="35.62609941353" lon="139.78164551658">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1303" lat="35.62609941401" lon="139.78164551624">
     <tag k="local_x" v="89673.9186"/>
     <tag k="local_y" v="43162.0332"/>
     <tag k="ele" v="43.2619"/>
   </node>
-  <node id="1304" lat="35.6260883621" lon="139.78165480661">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1304" lat="35.62608836258" lon="139.78165480627">
     <tag k="local_x" v="89674.7447"/>
     <tag k="local_y" v="43160.797"/>
     <tag k="ele" v="43.2646"/>
   </node>
-  <node id="1305" lat="35.62607196597" lon="139.78166836402">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1305" lat="35.62607196645" lon="139.78166836368">
     <tag k="local_x" v="89675.9499"/>
     <tag k="local_y" v="43158.9632"/>
     <tag k="ele" v="43.2778"/>
   </node>
-  <node id="1306" lat="35.62606045908" lon="139.7816787078">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1306" lat="35.62606045956" lon="139.78167870746">
     <tag k="local_x" v="89676.8708"/>
     <tag k="local_y" v="43157.6753"/>
     <tag k="ele" v="43.2831"/>
   </node>
-  <node id="1307" lat="35.62604190647" lon="139.78168247105">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1307" lat="35.62604190695" lon="139.78168247071">
     <tag k="local_x" v="89677.1861"/>
     <tag k="local_y" v="43155.6133"/>
     <tag k="ele" v="43.2989"/>
   </node>
-  <node id="1308" lat="35.62603566923" lon="139.78167925399">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89676.8862"/>
-    <tag k="local_y" v="43154.9251"/>
-    <tag k="ele" v="43.3042"/>
-  </node>
-  <node id="1309" lat="35.62602338256" lon="139.78166464766">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1309" lat="35.62602338304" lon="139.78166464732">
     <tag k="local_x" v="89675.5466"/>
     <tag k="local_y" v="43153.5787"/>
     <tag k="ele" v="43.3201"/>
   </node>
-  <node id="1310" lat="35.62600836007" lon="139.78163752071">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1310" lat="35.62600836055" lon="139.78163752037">
     <tag k="local_x" v="89673.0694"/>
     <tag k="local_y" v="43151.9429"/>
     <tag k="ele" v="43.3413"/>
   </node>
-  <node id="1311" lat="35.62599753078" lon="139.781613061">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1311" lat="35.62599753126" lon="139.78161306066">
     <tag k="local_x" v="89670.8395"/>
     <tag k="local_y" v="43150.7692"/>
     <tag k="ele" v="43.3624"/>
   </node>
-  <node id="1312" lat="35.62599133984" lon="139.78158973125">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1312" lat="35.62599134031" lon="139.78158973091">
     <tag k="local_x" v="89668.7183"/>
     <tag k="local_y" v="43150.1087"/>
     <tag k="ele" v="43.3635"/>
   </node>
-  <node id="1313" lat="35.62605388026" lon="139.78168218778">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89677.1769"/>
-    <tag k="local_y" v="43156.9417"/>
-    <tag k="ele" v="43.2857"/>
-  </node>
-  <node id="1314" lat="35.6260312305" lon="139.78167593345">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1314" lat="35.62603123098" lon="139.78167593311">
     <tag k="local_x" v="89676.5794"/>
     <tag k="local_y" v="43154.4365"/>
     <tag k="ele" v="43.3069"/>
   </node>
-  <node id="1315" lat="35.6260197361" lon="139.78165747115">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1315" lat="35.62601973658" lon="139.78165747081">
     <tag k="local_x" v="89674.8917"/>
     <tag k="local_y" v="43153.1823"/>
     <tag k="ele" v="43.3254"/>
   </node>
-  <node id="1316" lat="35.62599417138" lon="139.78156295842">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1316" lat="35.62599417186" lon="139.78156295808">
     <tag k="local_x" v="89666.2977"/>
     <tag k="local_y" v="43150.4528"/>
     <tag k="ele" v="43.3444"/>
   </node>
-  <node id="1317" lat="35.62599819243" lon="139.78154263413">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1317" lat="35.62599819291" lon="139.78154263379">
     <tag k="local_x" v="89664.4627"/>
     <tag k="local_y" v="43150.9216"/>
     <tag k="ele" v="43.3252"/>
   </node>
-  <node id="1318" lat="35.62600115264" lon="139.78152029297">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1318" lat="35.62600115312" lon="139.78152029263">
     <tag k="local_x" v="89662.4436"/>
     <tag k="local_y" v="43151.275"/>
     <tag k="ele" v="43.3061"/>
   </node>
-  <node id="1319" lat="35.6259988738" lon="139.78149777955">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1319" lat="35.62599887428" lon="139.78149777921">
     <tag k="local_x" v="89660.4017"/>
     <tag k="local_y" v="43151.0475"/>
     <tag k="ele" v="43.2918"/>
   </node>
-  <node id="1320" lat="35.62593671643" lon="139.78142323853">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1320" lat="35.62593671691" lon="139.78142323819">
     <tag k="local_x" v="89653.566"/>
     <tag k="local_y" v="43144.2369"/>
     <tag k="ele" v="43.2296"/>
   </node>
-  <node id="1321" lat="35.62595621106" lon="139.78143336584">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1321" lat="35.62595621154" lon="139.7814333655">
     <tag k="local_x" v="89654.5099"/>
     <tag k="local_y" v="43146.3878"/>
     <tag k="ele" v="43.2487"/>
   </node>
-  <node id="1322" lat="35.62579769949" lon="139.78142735577">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89653.7478"/>
-    <tag k="local_y" v="43128.8131"/>
-    <tag k="ele" v="43.1739"/>
-  </node>
-  <node id="1323" lat="35.62575861376" lon="139.78138847595">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1323" lat="35.62575861424" lon="139.78138847561">
     <tag k="local_x" v="89650.1732"/>
     <tag k="local_y" v="43124.5215"/>
     <tag k="ele" v="43.0903"/>
   </node>
-  <node id="1324" lat="35.62575751073" lon="139.78135938432">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1324" lat="35.62575751121" lon="139.78135938398">
     <tag k="local_x" v="89647.5372"/>
     <tag k="local_y" v="43124.4318"/>
     <tag k="ele" v="43.1233"/>
   </node>
-  <node id="1847" lat="35.62580896322" lon="139.78146490095">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89657.1633"/>
-    <tag k="local_y" v="43130.0203"/>
+  <node id="1847" lat="35.62580911107" lon="139.78146449532">
+    <tag k="local_x" v="89657.1268"/>
+    <tag k="local_y" v="43130.0371"/>
     <tag k="ele" v="43.217"/>
   </node>
-  <node id="1848" lat="35.62580206951" lon="139.78146505967">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89657.1682"/>
-    <tag k="local_y" v="43129.2555"/>
-    <tag k="ele" v="43.2044"/>
-  </node>
-  <node id="1849" lat="35.62579517581" lon="139.7814652195">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89657.1732"/>
-    <tag k="local_y" v="43128.4907"/>
-    <tag k="ele" v="43.1917"/>
-  </node>
-  <node id="1850" lat="35.62578828211" lon="139.78146537932">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1850" lat="35.62578828259" lon="139.78146537899">
     <tag k="local_x" v="89657.1782"/>
     <tag k="local_y" v="43127.7259"/>
     <tag k="ele" v="43.1759"/>
   </node>
-  <node id="1851" lat="35.6257814224" lon="139.78146515656">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89657.1486"/>
-    <tag k="local_y" v="43126.9653"/>
-    <tag k="ele" v="43.1628"/>
-  </node>
-  <node id="1852" lat="35.62577472634" lon="139.78146319652">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1852" lat="35.62577472682" lon="139.78146319618">
     <tag k="local_x" v="89656.9619"/>
     <tag k="local_y" v="43126.2248"/>
     <tag k="ele" v="43.1566"/>
   </node>
-  <node id="1853" lat="35.62576830989" lon="139.78146017876">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89656.6798"/>
-    <tag k="local_y" v="43125.5165"/>
-    <tag k="ele" v="43.1478"/>
-  </node>
-  <node id="1854" lat="35.62576238513" lon="139.78145594548">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1854" lat="35.62576238561" lon="139.78145594514">
     <tag k="local_x" v="89656.2883"/>
     <tag k="local_y" v="43124.8641"/>
     <tag k="ele" v="43.1405"/>
   </node>
-  <node id="1855" lat="35.6257569865" lon="139.78145069272">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89655.8052"/>
-    <tag k="local_y" v="43124.2712"/>
-    <tag k="ele" v="43.1355"/>
-  </node>
-  <node id="1856" lat="35.62575242364" lon="139.78144445993">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1856" lat="35.62575242412" lon="139.78144445959">
     <tag k="local_x" v="89655.2345"/>
     <tag k="local_y" v="43123.7721"/>
     <tag k="ele" v="43.1309"/>
   </node>
-  <node id="1857" lat="35.62574797489" lon="139.78143809953">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89654.6524"/>
-    <tag k="local_y" v="43123.2858"/>
-    <tag k="ele" v="43.1258"/>
-  </node>
-  <node id="1858" lat="35.62574362444" lon="139.78143165261">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89654.0626"/>
-    <tag k="local_y" v="43122.8105"/>
-    <tag k="ele" v="43.1201"/>
-  </node>
-  <node id="1859" lat="35.6257395299" lon="139.78142492464">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89653.4477"/>
-    <tag k="local_y" v="43122.3639"/>
-    <tag k="ele" v="43.1133"/>
-  </node>
-  <node id="1860" lat="35.62573561691" lon="139.78141805036">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89652.8198"/>
-    <tag k="local_y" v="43121.9376"/>
-    <tag k="ele" v="43.106"/>
-  </node>
-  <node id="1861" lat="35.62573216735" lon="139.78141073286">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1861" lat="35.62573216783" lon="139.78141073252">
     <tag k="local_x" v="89652.1524"/>
     <tag k="local_y" v="43121.5632"/>
     <tag k="ele" v="43.1006"/>
   </node>
-  <node id="1862" lat="35.62572879416" lon="139.78140338881">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1862" lat="35.62572879463" lon="139.78140338847">
     <tag k="local_x" v="89651.4827"/>
     <tag k="local_y" v="43121.1973"/>
     <tag k="ele" v="43.0961"/>
   </node>
-  <node id="1863" lat="35.62572559271" lon="139.78139600019">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89650.8092"/>
-    <tag k="local_y" v="43120.8505"/>
-    <tag k="ele" v="43.0912"/>
-  </node>
-  <node id="1864" lat="35.62572267729" lon="139.78138863262">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1864" lat="35.62572267777" lon="139.78138863229">
     <tag k="local_x" v="89650.138"/>
     <tag k="local_y" v="43120.5354"/>
     <tag k="ele" v="43.0976"/>
   </node>
-  <node id="1866" lat="35.6257210296" lon="139.78137361206">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1866" lat="35.62572103008" lon="139.78137361172">
     <tag k="local_x" v="89648.7755"/>
     <tag k="local_y" v="43120.3695"/>
     <tag k="ele" v="43.1035"/>
   </node>
-  <node id="1867" lat="35.62572244981" lon="139.78136534498">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89648.0288"/>
-    <tag k="local_y" v="43120.5363"/>
-    <tag k="ele" v="43.1041"/>
-  </node>
-  <node id="1868" lat="35.62572361785" lon="139.78135701658">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1868" lat="35.62572361833" lon="139.78135701624">
     <tag k="local_x" v="89647.2762"/>
     <tag k="local_y" v="43120.6752"/>
     <tag k="ele" v="43.1141"/>
   </node>
-  <node id="1869" lat="35.62572490613" lon="139.78134871947">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89646.5266"/>
-    <tag k="local_y" v="43120.8274"/>
-    <tag k="ele" v="43.1238"/>
-  </node>
-  <node id="1870" lat="35.62572664096" lon="139.78134053927">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1870" lat="35.62572664144" lon="139.78134053893">
     <tag k="local_x" v="89645.7882"/>
     <tag k="local_y" v="43121.029"/>
     <tag k="ele" v="43.1264"/>
   </node>
-  <node id="1871" lat="35.6257283749" lon="139.78133235909">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89645.0498"/>
-    <tag k="local_y" v="43121.2305"/>
-    <tag k="ele" v="43.1289"/>
-  </node>
-  <node id="1872" lat="35.62572986016" lon="139.78132410648">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89644.3045"/>
-    <tag k="local_y" v="43121.4045"/>
-    <tag k="ele" v="43.1308"/>
-  </node>
-  <node id="1873" lat="35.62573123514" lon="139.78131582462">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89643.5564"/>
-    <tag k="local_y" v="43121.5663"/>
-    <tag k="ele" v="43.1326"/>
-  </node>
-  <node id="1874" lat="35.62573261102" lon="139.78130754276">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89642.8083"/>
-    <tag k="local_y" v="43121.7282"/>
-    <tag k="ele" v="43.1343"/>
-  </node>
-  <node id="1875" lat="35.62573420122" lon="139.78129932499">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89642.0663"/>
-    <tag k="local_y" v="43121.9138"/>
-    <tag k="ele" v="43.1359"/>
-  </node>
-  <node id="1876" lat="35.62573579414" lon="139.7812911094">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89641.3245"/>
-    <tag k="local_y" v="43122.0997"/>
-    <tag k="ele" v="43.1374"/>
-  </node>
-  <node id="1877" lat="35.62573675447" lon="139.7812827466">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1877" lat="35.62573675495" lon="139.78128274626">
     <tag k="local_x" v="89640.5685"/>
     <tag k="local_y" v="43122.2156"/>
     <tag k="ele" v="43.1385"/>
   </node>
-  <node id="1878" lat="35.6257380844" lon="139.78127446874">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89639.8207"/>
-    <tag k="local_y" v="43122.3724"/>
-    <tag k="ele" v="43.1396"/>
-  </node>
-  <node id="1879" lat="35.62573973513" lon="139.78126626331">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1879" lat="35.62573973561" lon="139.78126626297">
     <tag k="local_x" v="89639.0799"/>
     <tag k="local_y" v="43122.5647"/>
     <tag k="ele" v="43.1406"/>
   </node>
-  <node id="1880" lat="35.62574146007" lon="139.78125808547">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89638.3417"/>
-    <tag k="local_y" v="43122.7652"/>
-    <tag k="ele" v="43.1417"/>
-  </node>
-  <node id="1881" lat="35.62574381229" lon="139.78125015318">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1881" lat="35.62574381277" lon="139.78125015284">
     <tag k="local_x" v="89637.6266"/>
     <tag k="local_y" v="43123.035"/>
     <tag k="ele" v="43.1433"/>
   </node>
-  <node id="1882" lat="35.62574639546" lon="139.78124232451">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89636.9212"/>
-    <tag k="local_y" v="43123.3303"/>
-    <tag k="ele" v="43.145"/>
-  </node>
-  <node id="1883" lat="35.6257496918" lon="139.78123494328">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1883" lat="35.62574969228" lon="139.78123494294">
     <tag k="local_x" v="89636.2573"/>
     <tag k="local_y" v="43123.7042"/>
     <tag k="ele" v="43.1469"/>
   </node>
-  <node id="1884" lat="35.62575344201" lon="139.7812279549">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89635.6296"/>
-    <tag k="local_y" v="43124.128"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="1885" lat="35.62575804672" lon="139.78122165918">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1885" lat="35.6257580472" lon="139.78122165884">
     <tag k="local_x" v="89635.0658"/>
     <tag k="local_y" v="43124.6458"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1886" lat="35.62576298383" lon="139.78121578134">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89634.5403"/>
-    <tag k="local_y" v="43125.2"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="1887" lat="35.62576801317" lon="139.78121001915">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1887" lat="35.62576801365" lon="139.78121001881">
     <tag k="local_x" v="89634.0254"/>
     <tag k="local_y" v="43125.7643"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1889" lat="35.62577518409" lon="139.78120437795">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1889" lat="35.62577518457" lon="139.78120437761">
     <tag k="local_x" v="89633.5244"/>
     <tag k="local_y" v="43126.566"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1890" lat="35.62578235592" lon="139.78119873674">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89633.0234"/>
-    <tag k="local_y" v="43127.3678"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="1891" lat="35.62578952959" lon="139.78119309991">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1891" lat="35.62578953007" lon="139.78119309957">
     <tag k="local_x" v="89632.5228"/>
     <tag k="local_y" v="43128.1698"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1892" lat="35.62579670603" lon="139.78118746856">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89632.0227"/>
-    <tag k="local_y" v="43128.9721"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="1893" lat="35.6258038659" lon="139.78118180434">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1893" lat="35.62580386638" lon="139.781181804">
     <tag k="local_x" v="89631.5196"/>
     <tag k="local_y" v="43129.7726"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1894" lat="35.62581095779" lon="139.78117601526">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89631.0051"/>
-    <tag k="local_y" v="43130.5657"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="1895" lat="35.62581804324" lon="139.78117021302">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1895" lat="35.62581804372" lon="139.78117021268">
     <tag k="local_x" v="89630.4894"/>
     <tag k="local_y" v="43131.3581"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1896" lat="35.62582511583" lon="139.78116438779">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89629.9716"/>
-    <tag k="local_y" v="43132.1491"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="1897" lat="35.6258322316" lon="139.78115864251">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89629.4611"/>
-    <tag k="local_y" v="43132.9448"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="1898" lat="35.62583935656" lon="139.78115291366">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89628.9521"/>
-    <tag k="local_y" v="43133.7415"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="1899" lat="35.62584648152" lon="139.78114718481">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89628.4431"/>
-    <tag k="local_y" v="43134.5382"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="1900" lat="35.62585352017" lon="139.78114130267">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89627.9201"/>
-    <tag k="local_y" v="43135.3255"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="1901" lat="35.62586054139" lon="139.78113538987">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89627.3943"/>
-    <tag k="local_y" v="43136.1109"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="1902" lat="35.6258675626" lon="139.78112947707">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89626.8685"/>
-    <tag k="local_y" v="43136.8963"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="1903" lat="35.62587458382" lon="139.78112356427">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1903" lat="35.6258745843" lon="139.78112356393">
     <tag k="local_x" v="89626.3427"/>
     <tag k="local_y" v="43137.6817"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1904" lat="35.62588159675" lon="139.78111763503">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="1904" lat="35.62588159723" lon="139.78111763469">
     <tag k="local_x" v="89625.8154"/>
     <tag k="local_y" v="43138.4662"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1905" lat="35.62588863543" lon="139.78111175509">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89625.2926"/>
-    <tag k="local_y" v="43139.2535"/>
+  <node id="1910" lat="35.62592453092" lon="139.78108068137">
+    <tag k="local_x" v="89622.528"/>
+    <tag k="local_y" v="43143.2697"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1906" lat="35.62589595738" lon="139.7811064274">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89624.8202"/>
-    <tag k="local_y" v="43140.0716"/>
+  <node id="1915" lat="35.62596013243" lon="139.78105205615">
+    <tag k="local_x" v="89619.9847"/>
+    <tag k="local_y" v="43147.2506"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1907" lat="35.62590327935" lon="139.78110110082">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89624.3479"/>
-    <tag k="local_y" v="43140.8897"/>
+  <node id="1921" lat="35.62600404958" lon="139.78102052413">
+    <tag k="local_x" v="89617.1896"/>
+    <tag k="local_y" v="43152.1571"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1908" lat="35.62591055615" lon="139.78109567774">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89623.8668"/>
-    <tag k="local_y" v="43141.7029"/>
+  <node id="1926" lat="35.62605063381" lon="139.78099266413">
+    <tag k="local_x" v="89614.7307"/>
+    <tag k="local_y" v="43157.3553"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1909" lat="35.62591775652" lon="139.7810900957">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89623.3712"/>
-    <tag k="local_y" v="43142.5078"/>
+  <node id="1930" lat="35.62607315575" lon="139.78098316674">
+    <tag k="local_x" v="89613.9016"/>
+    <tag k="local_y" v="43159.864"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1910" lat="35.62592495414" lon="139.78108450929">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89622.8752"/>
-    <tag k="local_y" v="43143.3124"/>
+  <node id="1931" lat="35.62608158131" lon="139.78098176671">
+    <tag k="local_x" v="89613.7864"/>
+    <tag k="local_y" v="43160.8001"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1911" lat="35.62593215086" lon="139.78107892289">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89622.3792"/>
-    <tag k="local_y" v="43144.1169"/>
+  <node id="1932" lat="35.62608994836" lon="139.7809819787">
+    <tag k="local_x" v="89613.8171"/>
+    <tag k="local_y" v="43161.7279"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1912" lat="35.62593937146" lon="139.78107338029">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89621.8872"/>
-    <tag k="local_y" v="43144.924"/>
+  <node id="1933" lat="35.62610063521" lon="139.78098326305">
+    <tag k="local_x" v="89613.9481"/>
+    <tag k="local_y" v="43162.9118"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1913" lat="35.62594641208" lon="139.78106751357">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89621.3656"/>
-    <tag k="local_y" v="43145.7115"/>
+  <node id="1934" lat="35.62611112614" lon="139.78098656787">
+    <tag k="local_x" v="89614.2618"/>
+    <tag k="local_y" v="43164.0717"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1914" lat="35.62595345358" lon="139.78106164572">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89620.8439"/>
-    <tag k="local_y" v="43146.4991"/>
+  <node id="1936" lat="35.62611909279" lon="139.78099300738">
+    <tag k="local_x" v="89614.8559"/>
+    <tag k="local_y" v="43164.9481"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1915" lat="35.62596055566" lon="139.78105588407">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89620.3319"/>
-    <tag k="local_y" v="43147.2933"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="1916" lat="35.62596767415" lon="139.78105014094">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89619.8216"/>
-    <tag k="local_y" v="43148.0893"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="1917" lat="35.62597479176" lon="139.78104439893">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89619.3114"/>
-    <tag k="local_y" v="43148.8852"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="1918" lat="35.62598190843" lon="139.78103865362">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89618.8009"/>
-    <tag k="local_y" v="43149.681"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="1919" lat="35.6259889976" lon="139.78103286345">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89618.2863"/>
-    <tag k="local_y" v="43150.4738"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="1920" lat="35.62599610054" lon="139.78102709847">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89617.774"/>
-    <tag k="local_y" v="43151.2681"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="1921" lat="35.62600324205" lon="139.78102140247">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89617.268"/>
-    <tag k="local_y" v="43152.0666"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="1922" lat="35.62601039645" lon="139.78101573277">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89616.7644"/>
-    <tag k="local_y" v="43152.8665"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="1923" lat="35.62601759503" lon="139.78101015185">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89616.2689"/>
-    <tag k="local_y" v="43153.6712"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="1924" lat="35.62602494206" lon="139.78100489775">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89615.8032"/>
-    <tag k="local_y" v="43154.492"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="1925" lat="35.62603219677" lon="139.78099942971">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89615.318"/>
-    <tag k="local_y" v="43155.3028"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="1926" lat="35.62603938237" lon="139.78099381365">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89614.8193"/>
-    <tag k="local_y" v="43156.1061"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="1927" lat="35.62604651191" lon="139.78098809353">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89614.3111"/>
-    <tag k="local_y" v="43156.9033"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="1928" lat="35.62605371706" lon="139.78098253901">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89613.818"/>
-    <tag k="local_y" v="43157.7087"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="1929" lat="35.62606092304" lon="139.78097697675">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89613.3242"/>
-    <tag k="local_y" v="43158.5142"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="1930" lat="35.62606857123" lon="139.78097261694">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89612.9399"/>
-    <tag k="local_y" v="43159.3674"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="1931" lat="35.62607634337" lon="139.78096865499">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89612.5918"/>
-    <tag k="local_y" v="43160.2339"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="1932" lat="35.62608447029" lon="139.78096607572">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89612.3694"/>
-    <tag k="local_y" v="43161.1382"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="1933" lat="35.62609342042" lon="139.78096466">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89612.2535"/>
-    <tag k="local_y" v="43162.1325"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="1934" lat="35.62610261811" lon="139.78096561248">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89612.3524"/>
-    <tag k="local_y" v="43163.1516"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="1935" lat="35.6261109515" lon="139.78096713133">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89612.5014"/>
-    <tag k="local_y" v="43164.0742"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="1936" lat="35.62611743535" lon="139.7809700376">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89612.7735"/>
-    <tag k="local_y" v="43164.7901"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="1937" lat="35.62612295968" lon="139.78097514711">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89613.2438"/>
-    <tag k="local_y" v="43165.3971"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="1938" lat="35.62612941285" lon="139.78098206013">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89613.8787"/>
-    <tag k="local_y" v="43166.1051"/>
+  <node id="1938" lat="35.62612749677" lon="139.78100417424">
+    <tag k="local_x" v="89615.8787"/>
+    <tag k="local_y" v="43165.8677"/>
     <tag k="ele" v="43.1492"/>
   </node>
-  <node id="1939" lat="35.62613636229" lon="139.7809938222">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89614.9534"/>
-    <tag k="local_y" v="43166.8627"/>
+  <node id="1939" lat="35.62613232333" lon="139.78101686299">
+    <tag k="local_x" v="89617.0344"/>
+    <tag k="local_y" v="43166.3888"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1940" lat="35.62613937308" lon="139.78100499806">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89615.9696"/>
-    <tag k="local_y" v="43167.1841"/>
+  <node id="1940" lat="35.62613475037" lon="139.78102906585">
+    <tag k="local_x" v="89618.1428"/>
+    <tag k="local_y" v="43166.6443"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1941" lat="35.62613933011" lon="139.78102097636">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89617.4165"/>
-    <tag k="local_y" v="43167.1614"/>
+  <node id="1941" lat="35.62613579894" lon="139.78104457152">
+    <tag k="local_x" v="89619.5484"/>
+    <tag k="local_y" v="43166.7432"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1946" lat="35.62613528907" lon="139.7810464436">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89619.7172"/>
-    <tag k="local_y" v="43166.6846"/>
+  <node id="1946" lat="35.62613076048" lon="139.78106555732">
+    <tag k="local_x" v="89621.4419"/>
+    <tag k="local_y" v="43166.1608"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1947" lat="35.62613232503" lon="139.78105547844">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89620.5313"/>
-    <tag k="local_y" v="43166.3457"/>
+  <node id="1947" lat="35.6261212202" lon="139.78107921838">
+    <tag k="local_x" v="89622.6659"/>
+    <tag k="local_y" v="43165.0873"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1948" lat="35.62612692809" lon="139.78106429292">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89621.3221"/>
-    <tag k="local_y" v="43165.7372"/>
+  <node id="1948" lat="35.62610805776" lon="139.78109274007">
+    <tag k="local_x" v="89623.8723"/>
+    <tag k="local_y" v="43163.6122"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1949" lat="35.62611802751" lon="139.78107283261">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89622.0832"/>
-    <tag k="local_y" v="43164.7404"/>
+  <node id="1949" lat="35.62609556815" lon="139.78110299064">
+    <tag k="local_x" v="89624.7834"/>
+    <tag k="local_y" v="43162.2154"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1950" lat="35.62610001839" lon="139.78108682431">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89623.3255"/>
-    <tag k="local_y" v="43162.7272"/>
-    <tag k="ele" v="43.1489"/>
-  </node>
-  <node id="1954" lat="35.62607024463" lon="139.78111116488">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89625.4888"/>
-    <tag k="local_y" v="43159.3975"/>
+  <node id="1954" lat="35.6260773268" lon="139.78111479168">
+    <tag k="local_x" v="89625.827"/>
+    <tag k="local_y" v="43160.1789"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1955" lat="35.6260634492" lon="139.78111738236">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89626.0425"/>
-    <tag k="local_y" v="43158.6368"/>
+  <node id="1960" lat="35.62602869841" lon="139.78114788485">
+    <tag k="local_x" v="89628.757"/>
+    <tag k="local_y" v="43154.7481"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1956" lat="35.62605633056" lon="139.78112311224">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89626.5516"/>
-    <tag k="local_y" v="43157.8408"/>
+  <node id="1962" lat="35.62601410252" lon="139.78115847436">
+    <tag k="local_x" v="89629.6959"/>
+    <tag k="local_y" v="43153.1173"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1957" lat="35.62604940712" lon="139.78112915387">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89627.0892"/>
-    <tag k="local_y" v="43157.0661"/>
+  <node id="1970" lat="35.62595302144" lon="139.78119593503">
+    <tag k="local_x" v="89633.0043"/>
+    <tag k="local_y" v="43146.3004"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="1958" lat="35.62604232143" lon="139.78113493184">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89627.6027"/>
-    <tag k="local_y" v="43156.2737"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="1959" lat="35.62603517624" lon="139.78114062126">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89628.1081"/>
-    <tag k="local_y" v="43155.4748"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="1960" lat="35.62602808255" lon="139.78114641039">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89628.6226"/>
-    <tag k="local_y" v="43154.6815"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="1961" lat="35.62602101182" lon="139.78115224113">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89629.1409"/>
-    <tag k="local_y" v="43153.8907"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="1962" lat="35.62601389691" lon="139.7811579831">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89629.6511"/>
-    <tag k="local_y" v="43153.0951"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="1963" lat="35.62600669373" lon="139.78116355524">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89630.1458"/>
-    <tag k="local_y" v="43152.2899"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="1964" lat="35.62599927148" lon="139.78116868238">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89630.5999"/>
-    <tag k="local_y" v="43151.4609"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="1965" lat="35.62599193112" lon="139.78117397391">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89631.069"/>
-    <tag k="local_y" v="43150.6408"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="1966" lat="35.62598480062" lon="139.7811796896">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89631.5768"/>
-    <tag k="local_y" v="43149.8435"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="1967" lat="35.62597770691" lon="139.78118547651">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89632.0911"/>
-    <tag k="local_y" v="43149.0502"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="1968" lat="35.62597061593" lon="139.7811912667">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89632.6057"/>
-    <tag k="local_y" v="43148.2572"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="1969" lat="35.62596345224" lon="139.78119691001">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89633.1069"/>
-    <tag k="local_y" v="43147.4563"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="1970" lat="35.62595611552" lon="139.78120220479">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89633.5763"/>
-    <tag k="local_y" v="43146.6366"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="1971" lat="35.62594876402" lon="139.78120746336">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89634.0424"/>
-    <tag k="local_y" v="43145.8153"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="1972" lat="35.62594145916" lon="139.78121278858">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89634.5146"/>
-    <tag k="local_y" v="43144.9991"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="1973" lat="35.62593424884" lon="139.781218278">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89635.0018"/>
-    <tag k="local_y" v="43144.1932"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="1974" lat="35.62592704496" lon="139.78122378168">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89635.4903"/>
-    <tag k="local_y" v="43143.388"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="1975" lat="35.62592000906" lon="139.78122957985">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89636.0057"/>
-    <tag k="local_y" v="43142.6011"/>
-    <tag k="ele" v="43.1463"/>
-  </node>
-  <node id="1976" lat="35.62591328724" lon="139.78123576748">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89636.5568"/>
-    <tag k="local_y" v="43141.8486"/>
+  <node id="1976" lat="35.62590066461" lon="139.7812378139">
+    <tag k="local_x" v="89636.7248"/>
+    <tag k="local_y" v="43140.4462"/>
     <tag k="ele" v="43.1428"/>
   </node>
-  <node id="1977" lat="35.62590692624" lon="139.7812423295">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89637.1423"/>
-    <tag k="local_y" v="43141.1357"/>
+  <node id="1977" lat="35.62589251189" lon="139.78124550737">
+    <tag k="local_x" v="89637.4103"/>
+    <tag k="local_y" v="43139.5333"/>
     <tag k="ele" v="43.1397"/>
   </node>
-  <node id="1980" lat="35.6258854929" lon="139.78126425312">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89639.0982"/>
-    <tag k="local_y" v="43138.7338"/>
+  <node id="1980" lat="35.62587843542" lon="139.78125922728">
+    <tag k="local_x" v="89638.6334"/>
+    <tag k="local_y" v="43137.9566"/>
     <tag k="ele" v="43.1308"/>
   </node>
-  <node id="1986" lat="35.62587126301" lon="139.78128856304">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89641.2801"/>
-    <tag k="local_y" v="43137.1282"/>
+  <node id="1986" lat="35.62586297478" lon="139.78128058762">
+    <tag k="local_x" v="89640.5465"/>
+    <tag k="local_y" v="43136.2178"/>
     <tag k="ele" v="43.115"/>
   </node>
-  <node id="1987" lat="35.62586683419" lon="139.78130805537">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89643.0392"/>
-    <tag k="local_y" v="43136.6151"/>
+  <node id="1987" lat="35.62585938247" lon="139.78129863833">
+    <tag k="local_x" v="89642.1762"/>
+    <tag k="local_y" v="43135.7991"/>
     <tag k="ele" v="43.115"/>
   </node>
-  <node id="1988" lat="35.62586629509" lon="139.78132623974">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89644.6852"/>
-    <tag k="local_y" v="43136.5349"/>
+  <node id="1988" lat="35.62585884337" lon="139.7813168227">
+    <tag k="local_x" v="89643.8222"/>
+    <tag k="local_y" v="43135.7189"/>
     <tag k="ele" v="43.1149"/>
   </node>
-  <node id="1989" lat="35.62586966693" lon="139.7813350536">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89645.488"/>
-    <tag k="local_y" v="43136.899"/>
+  <node id="1989" lat="35.62586631772" lon="139.7813354685">
+    <tag k="local_x" v="89645.521"/>
+    <tag k="local_y" v="43136.527"/>
     <tag k="ele" v="43.1147"/>
   </node>
-  <node id="1990" lat="35.62587322377" lon="139.78134379618">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89646.2846"/>
-    <tag k="local_y" v="43137.2837"/>
+  <node id="1990" lat="35.62586987456" lon="139.78134421109">
+    <tag k="local_x" v="89646.3176"/>
+    <tag k="local_y" v="43136.9117"/>
     <tag k="ele" v="43.1145"/>
   </node>
-  <node id="1991" lat="35.62587902213" lon="139.78135121939">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89646.9648"/>
-    <tag k="local_y" v="43137.9185"/>
+  <node id="1991" lat="35.62588127899" lon="139.78135662662">
+    <tag k="local_x" v="89647.4576"/>
+    <tag k="local_y" v="43138.1627"/>
     <tag k="ele" v="43.1143"/>
   </node>
-  <node id="1992" lat="35.62588662786" lon="139.7813556712">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89647.3784"/>
-    <tag k="local_y" v="43138.7571"/>
+  <node id="1992" lat="35.62588888471" lon="139.78136107843">
+    <tag k="local_x" v="89647.8712"/>
+    <tag k="local_y" v="43139.0013"/>
     <tag k="ele" v="43.1141"/>
   </node>
-  <node id="1993" lat="35.62589459785" lon="139.78135736344">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89647.5426"/>
-    <tag k="local_y" v="43139.6392"/>
+  <node id="1993" lat="35.62590508565" lon="139.78136093635">
+    <tag k="local_x" v="89647.8806"/>
+    <tag k="local_y" v="43140.7984"/>
     <tag k="ele" v="43.1146"/>
   </node>
-  <node id="1994" lat="35.62590233928" lon="139.78135597936">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89647.4279"/>
-    <tag k="local_y" v="43140.4994"/>
-    <tag k="ele" v="43.1186"/>
-  </node>
-  <node id="1995" lat="35.625909701" lon="139.78135386781">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89647.2468"/>
-    <tag k="local_y" v="43141.3183"/>
-    <tag k="ele" v="43.1225"/>
-  </node>
-  <node id="1996" lat="35.62591747516" lon="139.78135135247">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89647.0297"/>
-    <tag k="local_y" v="43142.1834"/>
-    <tag k="ele" v="43.1255"/>
-  </node>
-  <node id="1997" lat="35.62592526117" lon="139.78134876075">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89646.8057"/>
-    <tag k="local_y" v="43143.0499"/>
+  <node id="1997" lat="35.62593011204" lon="139.78135338213">
+    <tag k="local_x" v="89647.2309"/>
+    <tag k="local_y" v="43143.5827"/>
     <tag k="ele" v="43.1285"/>
   </node>
-  <node id="1998" lat="35.62593303631" lon="139.78134589754">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89646.5571"/>
-    <tag k="local_y" v="43143.9155"/>
-    <tag k="ele" v="43.1321"/>
-  </node>
-  <node id="1999" lat="35.62594077437" lon="139.78134204106">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89646.2185"/>
-    <tag k="local_y" v="43144.7781"/>
+  <node id="1999" lat="35.62594359633" lon="139.78134395466">
+    <tag k="local_x" v="89646.3957"/>
+    <tag k="local_y" v="43145.0889"/>
     <tag k="ele" v="43.1381"/>
   </node>
-  <node id="2000" lat="35.62594834627" lon="139.78133744614">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89645.8128"/>
-    <tag k="local_y" v="43145.6231"/>
-    <tag k="ele" v="43.1432"/>
-  </node>
-  <node id="2001" lat="35.62595581674" lon="139.78133253915">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89645.3787"/>
-    <tag k="local_y" v="43146.4572"/>
+  <node id="2001" lat="35.62595684285" lon="139.78133499679">
+    <tag k="local_x" v="89645.6027"/>
+    <tag k="local_y" v="43146.5682"/>
     <tag k="ele" v="43.147"/>
   </node>
-  <node id="2002" lat="35.62596306681" lon="139.78132705576">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89644.8921"/>
-    <tag k="local_y" v="43147.2675"/>
-    <tag k="ele" v="43.1472"/>
-  </node>
-  <node id="2003" lat="35.62597027917" lon="139.78132150006">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89644.3989"/>
-    <tag k="local_y" v="43148.0737"/>
-    <tag k="ele" v="43.1475"/>
-  </node>
-  <node id="2004" lat="35.62597732425" lon="139.78131562776">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89643.8768"/>
-    <tag k="local_y" v="43148.8617"/>
-    <tag k="ele" v="43.1477"/>
-  </node>
-  <node id="2005" lat="35.62598450354" lon="139.78131001072">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89643.378"/>
-    <tag k="local_y" v="43149.6643"/>
-    <tag k="ele" v="43.1478"/>
-  </node>
-  <node id="2006" lat="35.6259917996" lon="139.78130461828">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="2006" lat="35.62599180008" lon="139.78130461794">
     <tag k="local_x" v="89642.8997"/>
     <tag k="local_y" v="43150.4796"/>
     <tag k="ele" v="43.1479"/>
   </node>
-  <node id="2007" lat="35.6259990708" lon="139.78129917432">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89642.4167"/>
-    <tag k="local_y" v="43151.2922"/>
-    <tag k="ele" v="43.1479"/>
-  </node>
-  <node id="2008" lat="35.62600628582" lon="139.78129361416">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="2008" lat="35.6260062863" lon="139.78129361382">
     <tag k="local_x" v="89641.9231"/>
     <tag k="local_y" v="43152.0987"/>
     <tag k="ele" v="43.1479"/>
   </node>
-  <node id="2009" lat="35.62601348798" lon="139.7812880299">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89641.4273"/>
-    <tag k="local_y" v="43152.9038"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="2010" lat="35.62602068464" lon="139.78128243688">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="2010" lat="35.62602068512" lon="139.78128243654">
     <tag k="local_x" v="89640.9307"/>
     <tag k="local_y" v="43153.7083"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="2011" lat="35.62602789602" lon="139.78127687235">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89640.4367"/>
-    <tag k="local_y" v="43154.5144"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="2012" lat="35.62603515431" lon="139.78127140098">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="2012" lat="35.62603515479" lon="139.78127140064">
     <tag k="local_x" v="89639.9512"/>
     <tag k="local_y" v="43155.3256"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="2013" lat="35.62604241171" lon="139.78126592961">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89639.4657"/>
-    <tag k="local_y" v="43156.1367"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="2014" lat="35.62604940542" lon="139.78125997085">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="2014" lat="35.6260494059" lon="139.78125997051">
     <tag k="local_x" v="89638.9357"/>
     <tag k="local_y" v="43156.9191"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="2015" lat="35.62605639821" lon="139.78125401099">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89638.4056"/>
-    <tag k="local_y" v="43157.7014"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="2016" lat="35.62606341667" lon="139.78124809271">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="2016" lat="35.62606341715" lon="139.78124809237">
     <tag k="local_x" v="89637.8793"/>
     <tag k="local_y" v="43158.4865"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="2017" lat="35.62607050947" lon="139.7812423036">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89637.3648"/>
-    <tag k="local_y" v="43159.2797"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="2018" lat="35.62607762433" lon="139.78123655723">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="2018" lat="35.62607762481" lon="139.78123655689">
     <tag k="local_x" v="89636.8542"/>
     <tag k="local_y" v="43160.0753"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="2019" lat="35.62608478879" lon="139.78123090064">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89636.3518"/>
-    <tag k="local_y" v="43160.8763"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="2020" lat="35.62609194958" lon="139.78122523749">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="2020" lat="35.62609195006" lon="139.78122523715">
     <tag k="local_x" v="89635.8488"/>
     <tag k="local_y" v="43161.6769"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="2021" lat="35.62609902493" lon="139.78121941772">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="2021" lat="35.62609902541" lon="139.78121941738">
     <tag k="local_x" v="89635.3315"/>
     <tag k="local_y" v="43162.4682"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="2022" lat="35.62610605709" lon="139.78121351689">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89634.8068"/>
-    <tag k="local_y" v="43163.2548"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="2023" lat="35.62611313702" lon="139.78120770368">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="2023" lat="35.6261131375" lon="139.78120770334">
     <tag k="local_x" v="89634.2901"/>
     <tag k="local_y" v="43164.0466"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="2024" lat="35.62612025095" lon="139.781201954">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89633.7792"/>
-    <tag k="local_y" v="43164.8421"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="2025" lat="35.62612730425" lon="139.7811960937">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="2025" lat="35.62612730473" lon="139.78119609336">
     <tag k="local_x" v="89633.2582"/>
     <tag k="local_y" v="43165.631"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="2026" lat="35.62613436674" lon="139.78119024983">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="2026" lat="35.62613436722" lon="139.78119024949">
     <tag k="local_x" v="89632.7387"/>
     <tag k="local_y" v="43166.4209"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="2027" lat="35.62614148087" lon="139.78118452002">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89632.2296"/>
-    <tag k="local_y" v="43167.2164"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="2028" lat="35.62614795804" lon="139.78117785573">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89631.635"/>
-    <tag k="local_y" v="43167.9423"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="2029" lat="35.62615394869" lon="139.78117068975">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89630.9943"/>
-    <tag k="local_y" v="43168.6148"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="2030" lat="35.62616553027" lon="139.78115401066">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="2030" lat="35.62616553075" lon="139.78115401032">
     <tag k="local_x" v="89629.4998"/>
     <tag k="local_y" v="43169.9181"/>
     <tag k="ele" v="43.1494"/>
   </node>
-  <node id="2036" lat="35.62617834388" lon="139.78114049537">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="2036" lat="35.62617834436" lon="139.78114049503">
     <tag k="local_x" v="89628.2935"/>
     <tag k="local_y" v="43171.3545"/>
     <tag k="ele" v="43.1471"/>
   </node>
-  <node id="2038" lat="35.6261930684" lon="139.78112078925">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="2038" lat="35.62619306888" lon="139.78112078891">
     <tag k="local_x" v="89626.5292"/>
     <tag k="local_y" v="43173.0098"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="2039" lat="35.62620394104" lon="139.78109267627">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="2039" lat="35.62620394152" lon="139.78109267593">
     <tag k="local_x" v="89623.9983"/>
     <tag k="local_y" v="43174.2473"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="2040" lat="35.62621482475" lon="139.78106966814">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="2040" lat="35.62621482523" lon="139.7810696678">
     <tag k="local_x" v="89621.9297"/>
     <tag k="local_y" v="43175.4803"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="2041" lat="35.62622700098" lon="139.78104813999">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="2041" lat="35.62622700146" lon="139.78104813965">
     <tag k="local_x" v="89619.9969"/>
     <tag k="local_y" v="43176.855"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="2042" lat="35.62624113749" lon="139.78103919725">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="2042" lat="35.62624113797" lon="139.78103919691">
     <tag k="local_x" v="89619.2065"/>
     <tag k="local_y" v="43178.433"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="2043" lat="35.62625667142" lon="139.78103577451">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="2043" lat="35.6262566719" lon="139.78103577417">
     <tag k="local_x" v="89618.9179"/>
     <tag k="local_y" v="43180.1598"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="2050" lat="35.62627146909" lon="139.78103559293">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="2050" lat="35.62627146957" lon="139.78103559259">
     <tag k="local_x" v="89618.9218"/>
     <tag k="local_y" v="43181.8013"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="2051" lat="35.62627677694" lon="139.7810357045">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89618.9392"/>
-    <tag k="local_y" v="43182.3899"/>
+  <node id="2051" lat="35.62628473011" lon="139.78104210083">
+    <tag k="local_x" v="89619.5294"/>
+    <tag k="local_y" v="43183.2648"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="2052" lat="35.62628963836" lon="139.78104393262">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89619.702"/>
-    <tag k="local_y" v="43183.8072"/>
+  <node id="2052" lat="35.62630074088" lon="139.78105461651">
+    <tag k="local_x" v="89620.6848"/>
+    <tag k="local_y" v="43185.0266"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="2055" lat="35.62630097925" lon="139.78106013347">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89621.1847"/>
-    <tag k="local_y" v="43185.0469"/>
+  <node id="2061" lat="35.62631955003" lon="139.78108030562">
+    <tag k="local_x" v="89623.037"/>
+    <tag k="local_y" v="43187.084"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="2056" lat="35.62630957424" lon="139.7810768133">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89622.707"/>
-    <tag k="local_y" v="43185.9815"/>
+  <node id="2062" lat="35.6263291913" lon="139.78109631585">
+    <tag k="local_x" v="89624.5001"/>
+    <tag k="local_y" v="43188.1354"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="2057" lat="35.62631491755" lon="139.78108479446">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89623.4371"/>
-    <tag k="local_y" v="43186.5652"/>
+  <node id="2063" lat="35.6263395218" lon="139.78112715922">
+    <tag k="local_x" v="89627.3074"/>
+    <tag k="local_y" v="43189.2466"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="2058" lat="35.62631958497" lon="139.78109351802">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89624.2335"/>
-    <tag k="local_y" v="43187.0731"/>
+  <node id="2064" lat="35.62634010238" lon="139.78113740135">
+    <tag k="local_x" v="89628.2357"/>
+    <tag k="local_y" v="43189.2995"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="2059" lat="35.62632399927" lon="139.78110244198">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89625.0477"/>
-    <tag k="local_y" v="43187.5527"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="2060" lat="35.62632811075" lon="139.78111155495">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89625.8786"/>
-    <tag k="local_y" v="43187.9985"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="2061" lat="35.62633214907" lon="139.78112065578">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89626.7083"/>
-    <tag k="local_y" v="43188.4362"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="2062" lat="35.62633604444" lon="139.78112961744">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89627.5252"/>
-    <tag k="local_y" v="43188.8582"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="2063" lat="35.62633878266" lon="139.78113925039">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89628.4013"/>
-    <tag k="local_y" v="43189.1511"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="2064" lat="35.62633936323" lon="139.78114949252">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89629.3296"/>
-    <tag k="local_y" v="43189.204"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="2065" lat="35.62633837419" lon="139.78115982804">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="2065" lat="35.62633837467" lon="139.7811598277">
     <tag k="local_x" v="89630.2642"/>
     <tag k="local_y" v="43189.0827"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="2066" lat="35.62633595655" lon="139.78116958122">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="2066" lat="35.62633595703" lon="139.78116958088">
     <tag k="local_x" v="89631.1441"/>
     <tag k="local_y" v="43188.8036"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="2067" lat="35.62633141832" lon="139.78117781287">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89631.8833"/>
-    <tag k="local_y" v="43188.291"/>
+  <node id="2067" lat="35.62633053411" lon="139.78117948237">
+    <tag k="local_x" v="89632.0333"/>
+    <tag k="local_y" v="43188.191"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="2068" lat="35.62632615006" lon="139.78118517882">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89632.5431"/>
-    <tag k="local_y" v="43187.6984"/>
+  <node id="2068" lat="35.62632526585" lon="139.78118684831">
+    <tag k="local_x" v="89632.6931"/>
+    <tag k="local_y" v="43187.5984"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="2069" lat="35.62632065036" lon="139.78119239257">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89633.1888"/>
-    <tag k="local_y" v="43187.0803"/>
+  <node id="2069" lat="35.62631976615" lon="139.78119406207">
+    <tag k="local_x" v="89633.3388"/>
+    <tag k="local_y" v="43186.9803"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="2070" lat="35.62631433176" lon="139.7811989573">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89633.7746"/>
-    <tag k="local_y" v="43186.3721"/>
+  <node id="2070" lat="35.62630853428" lon="139.78120511845">
+    <tag k="local_x" v="89634.3246"/>
+    <tag k="local_y" v="43185.7221"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="2071" lat="35.62630804956" lon="139.78120564404">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89634.3715"/>
-    <tag k="local_y" v="43185.6678"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="2072" lat="35.62630130695" lon="139.78121191484">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89634.9301"/>
-    <tag k="local_y" v="43184.9129"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="2073" lat="35.62629468162" lon="139.78121846103">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89635.5138"/>
-    <tag k="local_y" v="43184.1707"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="2074" lat="35.62628847931" lon="139.78122547011">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89636.14"/>
-    <tag k="local_y" v="43183.4749"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="2075" lat="35.62628233785" lon="139.78123252243">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89636.7702"/>
-    <tag k="local_y" v="43182.7858"/>
-    <tag k="ele" v="43.1478"/>
-  </node>
-  <node id="2076" lat="35.62627629727" lon="139.78123965494">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89637.4078"/>
-    <tag k="local_y" v="43182.1078"/>
+  <node id="2076" lat="35.62627896858" lon="139.78123630126">
+    <tag k="local_x" v="89637.1078"/>
+    <tag k="local_y" v="43182.4078"/>
     <tag k="ele" v="43.1477"/>
   </node>
-  <node id="2077" lat="35.62627117614" lon="139.78124712686">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89638.0774"/>
-    <tag k="local_y" v="43181.5314"/>
+  <node id="2077" lat="35.62627384744" lon="139.78124377318">
+    <tag k="local_x" v="89637.7774"/>
+    <tag k="local_y" v="43181.8314"/>
     <tag k="ele" v="43.1476"/>
   </node>
-  <node id="2078" lat="35.62626643504" lon="139.78125509104">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="2078" lat="35.62626643552" lon="139.7812550907">
     <tag k="local_x" v="89638.7921"/>
     <tag k="local_y" v="43180.9966"/>
     <tag k="ele" v="43.1474"/>
   </node>
-  <node id="2079" lat="35.62626238508" lon="139.78126381882">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="2079" lat="35.62626238556" lon="139.78126381848">
     <tag k="local_x" v="89639.5769"/>
     <tag k="local_y" v="43180.5376"/>
     <tag k="ele" v="43.1472"/>
   </node>
-  <node id="2080" lat="35.62626082184" lon="139.78127398857">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="2080" lat="35.62626082232" lon="139.78127398823">
     <tag k="local_x" v="89640.4957"/>
     <tag k="local_y" v="43180.3528"/>
     <tag k="ele" v="43.1471"/>
   </node>
-  <node id="2081" lat="35.62626049576" lon="139.78128435488">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="2081" lat="35.62626049624" lon="139.78128435454">
     <tag k="local_x" v="89641.434"/>
     <tag k="local_y" v="43180.305"/>
     <tag k="ele" v="43.147"/>
   </node>
-  <node id="2082" lat="35.6262613163" lon="139.78129470158">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="2082" lat="35.62626131678" lon="139.78129470124">
     <tag k="local_x" v="89642.3721"/>
     <tag k="local_y" v="43180.3844"/>
     <tag k="ele" v="43.147"/>
   </node>
-  <node id="2083" lat="35.62626282996" lon="139.78130485004">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="2083" lat="35.62626283044" lon="139.7813048497">
     <tag k="local_x" v="89643.2932"/>
     <tag k="local_y" v="43180.5409"/>
     <tag k="ele" v="43.147"/>
   </node>
-  <node id="2084" lat="35.62626557235" lon="139.781314452">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89644.1665"/>
-    <tag k="local_y" v="43180.8343"/>
+  <node id="2084" lat="35.62626742599" lon="139.78131939275">
+    <tag k="local_x" v="89644.6165"/>
+    <tag k="local_y" v="43181.0343"/>
     <tag k="ele" v="43.147"/>
   </node>
-  <node id="2085" lat="35.62626924606" lon="139.78132351751">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89644.9925"/>
-    <tag k="local_y" v="43181.2316"/>
+  <node id="2085" lat="35.6262710997" lon="139.78132845826">
+    <tag k="local_x" v="89645.4425"/>
+    <tag k="local_y" v="43181.4316"/>
     <tag k="ele" v="43.147"/>
   </node>
-  <node id="2086" lat="35.62627274665" lon="139.78133275902">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89645.8342"/>
-    <tag k="local_y" v="43181.6095"/>
+  <node id="2094" lat="35.62629394113" lon="139.78138021436">
+    <tag k="local_x" v="89650.1608"/>
+    <tag k="local_y" v="43183.907"/>
     <tag k="ele" v="43.147"/>
   </node>
-  <node id="2087" lat="35.62627608846" lon="139.78134216968">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89646.691"/>
-    <tag k="local_y" v="43181.9696"/>
+  <node id="2095" lat="35.62629853525" lon="139.78138900199">
+    <tag k="local_x" v="89650.9629"/>
+    <tag k="local_y" v="43184.4067"/>
     <tag k="ele" v="43.147"/>
   </node>
-  <node id="2088" lat="35.62627966845" lon="139.78135150717">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89647.5415"/>
-    <tag k="local_y" v="43182.3562"/>
+  <node id="2096" lat="35.62631650435" lon="139.78141766117">
+    <tag k="local_x" v="89653.5829"/>
+    <tag k="local_y" v="43186.3676"/>
     <tag k="ele" v="43.147"/>
   </node>
-  <node id="2089" lat="35.62628328169" lon="139.7813608331">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89648.391"/>
-    <tag k="local_y" v="43182.7465"/>
+  <node id="2097" lat="35.62632138899" lon="139.78142620255">
+    <tag k="local_x" v="89654.3631"/>
+    <tag k="local_y" v="43186.8998"/>
     <tag k="ele" v="43.147"/>
   </node>
-  <node id="2090" lat="35.62628703054" lon="139.78137010729">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89649.236"/>
-    <tag k="local_y" v="43183.1519"/>
+  <node id="2098" lat="35.62632802215" lon="139.78143771992">
+    <tag k="local_x" v="89655.4152"/>
+    <tag k="local_y" v="43187.6226"/>
     <tag k="ele" v="43.147"/>
   </node>
-  <node id="2091" lat="35.6262909086" lon="139.78137932099">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89650.0757"/>
-    <tag k="local_y" v="43183.5717"/>
+  <node id="2099" lat="35.62633277052" lon="139.78144624792">
+    <tag k="local_x" v="89656.194"/>
+    <tag k="local_y" v="43188.1397"/>
     <tag k="ele" v="43.147"/>
   </node>
-  <node id="2092" lat="35.62629506118" lon="139.78138839911">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89650.9035"/>
-    <tag k="local_y" v="43184.0221"/>
+  <node id="2100" lat="35.62633689449" lon="139.78145508355">
+    <tag k="local_x" v="89656.9998"/>
+    <tag k="local_y" v="43188.5872"/>
     <tag k="ele" v="43.147"/>
   </node>
-  <node id="2093" lat="35.62629941093" lon="139.78139736161">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89651.7211"/>
-    <tag k="local_y" v="43184.4945"/>
+  <node id="2101" lat="35.62633824513" lon="139.78146542884">
+    <tag k="local_x" v="89657.9385"/>
+    <tag k="local_y" v="43188.7254"/>
     <tag k="ele" v="43.147"/>
   </node>
-  <node id="2094" lat="35.62630395497" lon="139.78140618975">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89652.5268"/>
-    <tag k="local_y" v="43184.9886"/>
-    <tag k="ele" v="43.147"/>
-  </node>
-  <node id="2095" lat="35.62630854908" lon="139.78141497738">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89653.3289"/>
-    <tag k="local_y" v="43185.4883"/>
-    <tag k="ele" v="43.147"/>
-  </node>
-  <node id="2096" lat="35.62631340337" lon="139.78142354794">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89654.1117"/>
-    <tag k="local_y" v="43186.0171"/>
-    <tag k="ele" v="43.147"/>
-  </node>
-  <node id="2097" lat="35.626318288" lon="139.78143208933">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89654.8919"/>
-    <tag k="local_y" v="43186.5493"/>
-    <tag k="ele" v="43.147"/>
-  </node>
-  <node id="2098" lat="35.62632353549" lon="139.78144031491">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89655.644"/>
-    <tag k="local_y" v="43187.1221"/>
-    <tag k="ele" v="43.147"/>
-  </node>
-  <node id="2099" lat="35.62632828386" lon="139.78144884291">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89656.4228"/>
-    <tag k="local_y" v="43187.6392"/>
-    <tag k="ele" v="43.147"/>
-  </node>
-  <node id="2100" lat="35.62633240783" lon="139.78145767854">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89657.2286"/>
-    <tag k="local_y" v="43188.0867"/>
-    <tag k="ele" v="43.147"/>
-  </node>
-  <node id="2101" lat="35.62633501928" lon="139.78146699318">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89658.0757"/>
-    <tag k="local_y" v="43188.3659"/>
-    <tag k="ele" v="43.147"/>
-  </node>
-  <node id="2102" lat="35.62633692906" lon="139.78147673037">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89658.9601"/>
-    <tag k="local_y" v="43188.5668"/>
+  <node id="2102" lat="35.62633815305" lon="139.7814760224">
+    <tag k="local_x" v="89658.8977"/>
+    <tag k="local_y" v="43188.7033"/>
     <tag k="ele" v="43.1472"/>
   </node>
-  <node id="2103" lat="35.62633743982" lon="139.78148675823">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="2103" lat="35.6263374403" lon="139.78148675789">
     <tag k="local_x" v="89659.8689"/>
     <tag k="local_y" v="43188.6122"/>
     <tag k="ele" v="43.1472"/>
   </node>
-  <node id="2104" lat="35.62633449282" lon="139.78149632287">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="2104" lat="35.6263344933" lon="139.78149632253">
     <tag k="local_x" v="89660.731"/>
     <tag k="local_y" v="43188.2746"/>
     <tag k="ele" v="43.1474"/>
   </node>
-  <node id="2105" lat="35.62632919993" lon="139.78150437492">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89661.4529"/>
+  <node id="2105" lat="35.62632921716" lon="139.78150603073">
+    <tag k="local_x" v="89661.6029"/>
     <tag k="local_y" v="43187.6785"/>
     <tag k="ele" v="43.1475"/>
   </node>
-  <node id="2106" lat="35.6263223015" lon="139.78151021739">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89661.9725"/>
+  <node id="2106" lat="35.62632231874" lon="139.7815118732">
+    <tag k="local_x" v="89662.1225"/>
     <tag k="local_y" v="43186.9068"/>
     <tag k="ele" v="43.1477"/>
   </node>
-  <node id="2107" lat="35.6263146491" lon="139.78151371811">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89662.279"/>
+  <node id="2107" lat="35.62631468309" lon="139.78151703007">
+    <tag k="local_x" v="89662.579"/>
     <tag k="local_y" v="43186.0541"/>
     <tag k="ele" v="43.1479"/>
   </node>
-  <node id="2108" lat="35.62630704664" lon="139.78151591613">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89662.4676"/>
+  <node id="2108" lat="35.62630708062" lon="139.78151922809">
+    <tag k="local_x" v="89662.7676"/>
     <tag k="local_y" v="43185.2084"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="2109" lat="35.6263004697" lon="139.78151557201">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89662.4274"/>
-    <tag k="local_y" v="43184.4793"/>
+  <node id="2109" lat="35.62629421032" lon="139.78152063588">
+    <tag k="local_x" v="89662.8774"/>
+    <tag k="local_y" v="43183.7793"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="2110" lat="35.62629472736" lon="139.78151439808">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89662.3132"/>
-    <tag k="local_y" v="43183.8437"/>
+  <node id="2110" lat="35.62628169596" lon="139.78151846044">
+    <tag k="local_x" v="89662.6632"/>
+    <tag k="local_y" v="43182.3937"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="2111" lat="35.62628904749" lon="139.78151307191">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89662.1853"/>
-    <tag k="local_y" v="43183.2152"/>
+  <node id="2115" lat="35.62626902605" lon="139.78151668379">
+    <tag k="local_x" v="89662.4849"/>
+    <tag k="local_y" v="43180.9904"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="2112" lat="35.62628357438" lon="139.78151159794">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89662.0443"/>
-    <tag k="local_y" v="43182.6098"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="2113" lat="35.62627768001" lon="139.78151036889">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89661.9249"/>
-    <tag k="local_y" v="43181.9574"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="2114" lat="35.62627151417" lon="139.78150913071">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89661.8043"/>
-    <tag k="local_y" v="43181.2749"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="2115" lat="35.62626533044" lon="139.78150790605">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89661.6849"/>
-    <tag k="local_y" v="43180.5904"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="2116" lat="35.62625913138" lon="139.78150579047">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89661.4848"/>
+  <node id="2116" lat="35.62625920446" lon="139.78151296678">
+    <tag k="local_x" v="89662.1348"/>
     <tag k="local_y" v="43179.9052"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="2117" lat="35.62625308607" lon="139.78150265222">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89661.1923"/>
+  <node id="2117" lat="35.62625312564" lon="139.78150651623">
+    <tag k="local_x" v="89661.5423"/>
     <tag k="local_y" v="43179.2382"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="2118" lat="35.62624735861" lon="139.78149795875">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89660.7594"/>
-    <tag k="local_y" v="43178.6082"/>
+  <node id="2118" lat="35.62624617165" lon="139.78149875494">
+    <tag k="local_x" v="89660.8299"/>
+    <tag k="local_y" v="43178.4756"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="2119" lat="35.62624204644" lon="139.78149180577">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89660.1949"/>
-    <tag k="local_y" v="43178.0259"/>
+  <node id="2119" lat="35.62623887075" lon="139.78148700367">
+    <tag k="local_x" v="89659.7557"/>
+    <tag k="local_y" v="43177.679"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="2120" lat="35.62623736874" lon="139.7814846482">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89659.5403"/>
-    <tag k="local_y" v="43177.5151"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="2121" lat="35.62623313296" lon="139.78147679156">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89658.823"/>
-    <tag k="local_y" v="43177.0541"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="2122" lat="35.62622921743" lon="139.78146841878">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="2122" lat="35.62622921791" lon="139.78146841844">
     <tag k="local_x" v="89658.0594"/>
     <tag k="local_y" v="43176.6292"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="2123" lat="35.62622544358" lon="139.78145988042">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89657.281"/>
-    <tag k="local_y" v="43176.2202"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="2124" lat="35.62622235276" lon="139.78145059294">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89656.4357"/>
-    <tag k="local_y" v="43175.8878"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="2125" lat="35.62621912595" lon="139.78144131967">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89655.5915"/>
-    <tag k="local_y" v="43175.5403"/>
-    <tag k="ele" v="43.148"/>
-  </node>
-  <node id="2126" lat="35.62621571604" lon="139.7814319509">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="2126" lat="35.62621571652" lon="139.78143195056">
     <tag k="local_x" v="89654.7384"/>
     <tag k="local_y" v="43175.1726"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="2127" lat="35.62620983327" lon="139.7814100332">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="2127" lat="35.62620983375" lon="139.78141003286">
     <tag k="local_x" v="89652.7455"/>
     <tag k="local_y" v="43174.5447"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="2130" lat="35.62620098823" lon="139.7813811097">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="2130" lat="35.62620098871" lon="139.78138110936">
     <tag k="local_x" v="89650.1141"/>
     <tag k="local_y" v="43173.5961"/>
     <tag k="ele" v="43.1487"/>
   </node>
-  <node id="2139" lat="35.62619245898" lon="139.78134784275">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="2139" lat="35.62619245946" lon="139.78134784241">
     <tag k="local_x" v="89647.0898"/>
     <tag k="local_y" v="43172.6874"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="2141" lat="35.62617347932" lon="139.7813226719">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="2141" lat="35.6261734798" lon="139.78132267156">
     <tag k="local_x" v="89644.7843"/>
     <tag k="local_y" v="43170.6105"/>
     <tag k="ele" v="43.1508"/>
   </node>
-  <node id="2142" lat="35.62615509702" lon="139.78131697901">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89644.2435"/>
-    <tag k="local_y" v="43168.578"/>
+  <node id="2142" lat="35.62614988794" lon="139.78131392824">
+    <tag k="local_x" v="89643.9601"/>
+    <tag k="local_y" v="43168.0036"/>
     <tag k="ele" v="43.1467"/>
   </node>
-  <node id="2143" lat="35.62614071146" lon="139.78132198103">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89644.6767"/>
-    <tag k="local_y" v="43166.9768"/>
+  <node id="2143" lat="35.62613550237" lon="139.78131893026">
+    <tag k="local_x" v="89644.3933"/>
+    <tag k="local_y" v="43166.4024"/>
     <tag k="ele" v="43.1477"/>
   </node>
-  <node id="2144" lat="35.62612400716" lon="139.7813310963">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89645.4792"/>
-    <tag k="local_y" v="43165.1138"/>
+  <node id="2144" lat="35.62611879807" lon="139.78132804553">
+    <tag k="local_x" v="89645.1958"/>
+    <tag k="local_y" v="43164.5394"/>
     <tag k="ele" v="43.148"/>
   </node>
-  <node id="2147" lat="35.6261080576" lon="139.78135252153">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="2147" lat="35.62610805808" lon="139.78135252119">
     <tag k="local_x" v="89647.3975"/>
     <tag k="local_y" v="43163.3207"/>
     <tag k="ele" v="43.145"/>
   </node>
-  <node id="2148" lat="35.62610504386" lon="139.78136226053">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89648.2753"/>
-    <tag k="local_y" v="43162.9755"/>
-    <tag k="ele" v="43.1347"/>
-  </node>
-  <node id="2149" lat="35.62610176671" lon="139.78137189641">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="2149" lat="35.62610176719" lon="139.78137189607">
     <tag k="local_x" v="89649.1434"/>
     <tag k="local_y" v="43162.6012"/>
     <tag k="ele" v="43.1244"/>
   </node>
-  <node id="2150" lat="35.62609856296" lon="139.78138156872">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89650.0149"/>
-    <tag k="local_y" v="43162.235"/>
-    <tag k="ele" v="43.1141"/>
-  </node>
-  <node id="2151" lat="35.62609539999" lon="139.7813912614">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89650.8883"/>
-    <tag k="local_y" v="43161.8733"/>
+  <node id="2151" lat="35.62609606322" lon="139.78138966527">
+    <tag k="local_x" v="89650.7447"/>
+    <tag k="local_y" v="43161.9486"/>
     <tag k="ele" v="43.1038"/>
   </node>
-  <node id="2152" lat="35.6260926009" lon="139.78140109762">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89651.7752"/>
-    <tag k="local_y" v="43161.5518"/>
+  <node id="2152" lat="35.62609292659" lon="139.78139839794">
+    <tag k="local_x" v="89651.5312"/>
+    <tag k="local_y" v="43161.5909"/>
     <tag k="ele" v="43.0935"/>
   </node>
-  <node id="2153" lat="35.62608959892" lon="139.78141084086">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89652.6534"/>
-    <tag k="local_y" v="43161.2079"/>
+  <node id="2153" lat="35.62608932058" lon="139.78141028268">
+    <tag k="local_x" v="89652.6025"/>
+    <tag k="local_y" v="43161.1776"/>
     <tag k="ele" v="43.0814"/>
   </node>
-  <node id="2154" lat="35.62608618758" lon="139.78142040258">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89653.5146"/>
-    <tag k="local_y" v="43160.8188"/>
-    <tag k="ele" v="43.0687"/>
-  </node>
-  <node id="2155" lat="35.62608265298" lon="139.78142989991">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="2155" lat="35.62608265346" lon="139.78142989957">
     <tag k="local_x" v="89654.3698"/>
     <tag k="local_y" v="43160.4161"/>
     <tag k="ele" v="43.0561"/>
   </node>
-  <node id="2156" lat="35.62607930491" lon="139.78143947723">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89655.2325"/>
-    <tag k="local_y" v="43160.034"/>
-    <tag k="ele" v="43.0435"/>
-  </node>
-  <node id="2157" lat="35.62607763151" lon="139.78144936373">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="2157" lat="35.62607763199" lon="139.78144936339">
     <tag k="local_x" v="89656.1255"/>
     <tag k="local_y" v="43159.8373"/>
     <tag k="ele" v="43.0291"/>
   </node>
-  <node id="2158" lat="35.62607720757" lon="139.78146128742">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89657.2047"/>
-    <tag k="local_y" v="43159.7769"/>
+  <node id="2158" lat="35.62607613163" lon="139.78146744424">
+    <tag k="local_x" v="89657.7608"/>
+    <tag k="local_y" v="43159.6506"/>
     <tag k="ele" v="43.0112"/>
   </node>
-  <node id="2159" lat="35.62608077275" lon="139.78148146128">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89659.0365"/>
-    <tag k="local_y" v="43160.1497"/>
+  <node id="2159" lat="35.6260796695" lon="139.78149008766">
+    <tag k="local_x" v="89659.8162"/>
+    <tag k="local_y" v="43160.0176"/>
     <tag k="ele" v="42.9929"/>
   </node>
-  <node id="2165" lat="35.6260868102" lon="139.78150726252">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="2165" lat="35.62608681068" lon="139.78150726218">
     <tag k="local_x" v="89661.3813"/>
     <tag k="local_y" v="43160.7904"/>
     <tag k="ele" v="42.9385"/>
   </node>
-  <node id="2168" lat="35.62610658349" lon="139.78152336856">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89662.867"/>
-    <tag k="local_y" v="43162.9655"/>
+  <node id="2168" lat="35.62609829536" lon="139.78152520672">
+    <tag k="local_x" v="89663.0221"/>
+    <tag k="local_y" v="43162.0441"/>
     <tag k="ele" v="43.0052"/>
   </node>
-  <node id="2169" lat="35.62611564321" lon="139.78152984565">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="2169" lat="35.62611564369" lon="139.78152984531">
     <tag k="local_x" v="89663.466"/>
     <tag k="local_y" v="43163.9631"/>
     <tag k="ele" v="43.0277"/>
   </node>
-  <node id="2170" lat="35.6261340399" lon="139.78153517948">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89663.9743"/>
-    <tag k="local_y" v="43165.9976"/>
+  <node id="2170" lat="35.62613325572" lon="139.78153319011">
+    <tag k="local_x" v="89663.7931"/>
+    <tag k="local_y" v="43165.9128"/>
     <tag k="ele" v="43.0492"/>
   </node>
-  <node id="2173" lat="35.62614929283" lon="139.78153499329">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="2173" lat="35.62614929331" lon="139.78153499295">
     <tag k="local_x" v="89663.9784"/>
     <tag k="local_y" v="43167.6896"/>
     <tag k="ele" v="43.1002"/>
   </node>
-  <node id="2174" lat="35.6261672928" lon="139.78154620786">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="2174" lat="35.62616729328" lon="139.78154620752">
     <tag k="local_x" v="89665.0187"/>
     <tag k="local_y" v="43169.6735"/>
     <tag k="ele" v="43.1087"/>
   </node>
-  <node id="2175" lat="35.62617753581" lon="139.78156244087">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="2175" lat="35.62617753629" lon="139.78156244053">
     <tag k="local_x" v="89666.5028"/>
     <tag k="local_y" v="43170.7914"/>
     <tag k="ele" v="43.1189"/>
   </node>
-  <node id="2176" lat="35.6261829985" lon="139.78158124649">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="2176" lat="35.62618299898" lon="139.78158124615">
     <tag k="local_x" v="89668.2133"/>
     <tag k="local_y" v="43171.3762"/>
     <tag k="ele" v="43.1282"/>
   </node>
-  <node id="2181" lat="35.62618510823" lon="139.78160085831">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="2181" lat="35.62618510871" lon="139.78160085797">
     <tag k="local_x" v="89669.9922"/>
     <tag k="local_y" v="43171.5882"/>
     <tag k="ele" v="43.1044"/>
   </node>
-  <node id="2184" lat="35.62617994811" lon="139.78162506819">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="2184" lat="35.62617994859" lon="139.78162506785">
     <tag k="local_x" v="89672.1775"/>
     <tag k="local_y" v="43170.9887"/>
     <tag k="ele" v="43.0629"/>
   </node>
-  <node id="2185" lat="35.62617227605" lon="139.78163411372">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="2185" lat="35.62617227653" lon="139.78163411338">
     <tag k="local_x" v="89672.9861"/>
     <tag k="local_y" v="43170.1276"/>
     <tag k="ele" v="43.0517"/>
   </node>
-  <node id="2186" lat="35.62616508095" lon="139.78164084298">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="2186" lat="35.62616508143" lon="139.78164084264">
     <tag k="local_x" v="89673.5856"/>
     <tag k="local_y" v="43169.322"/>
     <tag k="ele" v="43.0442"/>
   </node>
-  <node id="2187" lat="35.6261588935" lon="139.78164762983">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="2187" lat="35.62615889398" lon="139.78164762949">
     <tag k="local_x" v="89674.1917"/>
     <tag k="local_y" v="43168.6281"/>
     <tag k="ele" v="43.023"/>
   </node>
-  <node id="2188" lat="35.62615188843" lon="139.78165353684">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="2188" lat="35.62615188891" lon="139.7816535365">
     <tag k="local_x" v="89674.717"/>
     <tag k="local_y" v="43167.8445"/>
     <tag k="ele" v="43.0029"/>
   </node>
-  <node id="2189" lat="35.6261443442" lon="139.78165801648">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="2189" lat="35.62614434468" lon="139.78165801614">
     <tag k="local_x" v="89675.1123"/>
     <tag k="local_y" v="43167.0027"/>
     <tag k="ele" v="42.9795"/>
   </node>
-  <node id="2190" lat="35.62613693345" lon="139.78166303519">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="2190" lat="35.62613693393" lon="139.78166303485">
     <tag k="local_x" v="89675.5566"/>
     <tag k="local_y" v="43166.1751"/>
     <tag k="ele" v="42.9498"/>
   </node>
-  <node id="2191" lat="35.62612975759" lon="139.7816686367">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="2191" lat="35.62612975807" lon="139.78166863636">
     <tag k="local_x" v="89676.054"/>
     <tag k="local_y" v="43165.3729"/>
     <tag k="ele" v="42.9191"/>
   </node>
-  <node id="2192" lat="35.62612273499" lon="139.78167441477">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89676.5676"/>
-    <tag k="local_y" v="43164.5875"/>
-    <tag k="ele" v="42.8487"/>
-  </node>
-  <node id="2193" lat="35.6261155875" lon="139.78167996836">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89677.0607"/>
-    <tag k="local_y" v="43163.7885"/>
+  <node id="2193" lat="35.62611616572" lon="139.78168146658">
+    <tag k="local_x" v="89677.1972"/>
+    <tag k="local_y" v="43163.8509"/>
     <tag k="ele" v="42.7789"/>
   </node>
-  <node id="2194" lat="35.62610899414" lon="139.78168646873">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89677.6403"/>
-    <tag k="local_y" v="43163.0499"/>
+  <node id="2194" lat="35.62610957236" lon="139.78168796695">
+    <tag k="local_x" v="89677.7768"/>
+    <tag k="local_y" v="43163.1123"/>
     <tag k="ele" v="42.7462"/>
   </node>
-  <node id="2195" lat="35.62610250621" lon="139.78169314198">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89678.2357"/>
-    <tag k="local_y" v="43162.3228"/>
+  <node id="2195" lat="35.62610308444" lon="139.7816946402">
+    <tag k="local_x" v="89678.3722"/>
+    <tag k="local_y" v="43162.3852"/>
     <tag k="ele" v="42.707"/>
   </node>
-  <node id="2196" lat="35.62609613648" lon="139.78169991282">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89678.8401"/>
-    <tag k="local_y" v="43161.6087"/>
+  <node id="2196" lat="35.6260967147" lon="139.78170141104">
+    <tag k="local_x" v="89678.9766"/>
+    <tag k="local_y" v="43161.6711"/>
     <tag k="ele" v="42.6735"/>
   </node>
-  <node id="2197" lat="35.6260897157" lon="139.78170662921">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89679.4395"/>
-    <tag k="local_y" v="43160.889"/>
+  <node id="2197" lat="35.62609029393" lon="139.78170812743">
+    <tag k="local_x" v="89679.576"/>
+    <tag k="local_y" v="43160.9514"/>
     <tag k="ele" v="42.6586"/>
   </node>
-  <node id="2198" lat="35.62608315205" lon="139.78171321416">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="2198" lat="35.62608315253" lon="139.78171321382">
     <tag k="local_x" v="89680.0268"/>
     <tag k="local_y" v="43160.1536"/>
     <tag k="ele" v="42.6493"/>
   </node>
-  <node id="2199" lat="35.62607552879" lon="139.78171719034">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="2199" lat="35.62607552927" lon="139.78171719">
     <tag k="local_x" v="89680.3764"/>
     <tag k="local_y" v="43159.3036"/>
     <tag k="ele" v="42.6724"/>
   </node>
-  <node id="2200" lat="35.62606763031" lon="139.78171918081">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="2200" lat="35.62606763079" lon="139.78171918047">
     <tag k="local_x" v="89680.5458"/>
     <tag k="local_y" v="43158.4253"/>
     <tag k="ele" v="42.6865"/>
   </node>
-  <node id="2201" lat="35.62605938602" lon="139.78172023127">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89680.6296"/>
-    <tag k="local_y" v="43157.5097"/>
-    <tag k="ele" v="42.7088"/>
-  </node>
-  <node id="2202" lat="35.62605096066" lon="139.78171897766">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="2202" lat="35.62605096114" lon="139.78171897732">
     <tag k="local_x" v="89680.5045"/>
     <tag k="local_y" v="43156.5766"/>
     <tag k="ele" v="42.7437"/>
   </node>
-  <node id="2203" lat="35.62604285736" lon="139.78171604952">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89680.2282"/>
-    <tag k="local_y" v="43155.6811"/>
+  <node id="2203" lat="35.62604042515" lon="139.78171460195">
+    <tag k="local_x" v="89680.0938"/>
+    <tag k="local_y" v="43155.4129"/>
     <tag k="ele" v="42.771"/>
   </node>
-  <node id="2204" lat="35.62603509022" lon="139.78171230685">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89679.8786"/>
-    <tag k="local_y" v="43154.8238"/>
-    <tag k="ele" v="42.7969"/>
-  </node>
-  <node id="2205" lat="35.62602846453" lon="139.78170705279">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="2205" lat="35.62602846501" lon="139.78170705245">
     <tag k="local_x" v="89679.3937"/>
     <tag k="local_y" v="43154.0948"/>
     <tag k="ele" v="42.8246"/>
   </node>
-  <node id="2206" lat="35.62602192539" lon="139.78170188796">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89678.917"/>
-    <tag k="local_y" v="43153.3753"/>
-    <tag k="ele" v="42.8601"/>
-  </node>
-  <node id="2207" lat="35.62601533379" lon="139.78169706294">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89678.471"/>
-    <tag k="local_y" v="43152.6496"/>
-    <tag k="ele" v="42.91"/>
-  </node>
-  <node id="2208" lat="35.62600864004" lon="139.78169158686">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89677.9659"/>
-    <tag k="local_y" v="43151.9133"/>
-    <tag k="ele" v="42.9511"/>
-  </node>
-  <node id="2209" lat="35.62600210009" lon="139.78168545029">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="2209" lat="35.62600210057" lon="139.78168544995">
     <tag k="local_x" v="89677.4012"/>
     <tag k="local_y" v="43151.1948"/>
     <tag k="ele" v="42.9886"/>
   </node>
-  <node id="2210" lat="35.62599607741" lon="139.78167866651">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="2210" lat="35.62599607789" lon="139.78167866617">
     <tag k="local_x" v="89676.7786"/>
     <tag k="local_y" v="43150.5344"/>
     <tag k="ele" v="43.0277"/>
   </node>
-  <node id="2211" lat="35.62599087778" lon="139.78167098131">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89676.0755"/>
-    <tag k="local_y" v="43149.9663"/>
-    <tag k="ele" v="43.0444"/>
-  </node>
-  <node id="2212" lat="35.62598584408" lon="139.78166312133">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89675.3568"/>
-    <tag k="local_y" v="43149.4168"/>
-    <tag k="ele" v="43.0628"/>
-  </node>
-  <node id="2213" lat="35.62597812198" lon="139.7816526">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89674.3934"/>
-    <tag k="local_y" v="43148.5721"/>
-    <tag k="ele" v="43.0784"/>
-  </node>
-  <node id="2214" lat="35.62596975965" lon="139.78163894896">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89673.1457"/>
-    <tag k="local_y" v="43147.6599"/>
-    <tag k="ele" v="43.0921"/>
-  </node>
-  <node id="2218" lat="35.6259648246" lon="139.78162916606">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="2218" lat="35.62596482508" lon="139.78162916572">
     <tag k="local_x" v="89672.253"/>
     <tag k="local_y" v="43147.1235"/>
     <tag k="ele" v="43.1875"/>
   </node>
-  <node id="2219" lat="35.62596209063" lon="139.78161272859">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="2219" lat="35.62596209111" lon="139.78161272825">
     <tag k="local_x" v="89670.7607"/>
     <tag k="local_y" v="43146.8387"/>
     <tag k="ele" v="43.202"/>
   </node>
-  <node id="2221" lat="35.62596501324" lon="139.78158524214">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="2221" lat="35.62596501372" lon="139.7815852418">
     <tag k="local_x" v="89668.2756"/>
     <tag k="local_y" v="43147.1937"/>
     <tag k="ele" v="43.2422"/>
   </node>
-  <node id="2222" lat="35.6259692325" lon="139.78155465401">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="2222" lat="35.62596923298" lon="139.78155465367">
     <tag k="local_x" v="89665.5114"/>
     <tag k="local_y" v="43147.696"/>
     <tag k="ele" v="43.2575"/>
   </node>
-  <node id="2223" lat="35.62597160769" lon="139.78153419458">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="2223" lat="35.62597160816" lon="139.78153419424">
     <tag k="local_x" v="89663.6619"/>
     <tag k="local_y" v="43147.9824"/>
     <tag k="ele" v="43.2694"/>
   </node>
-  <node id="2225" lat="35.62597046318" lon="139.78151731005">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="2225" lat="35.62597046366" lon="139.78151730971">
     <tag k="local_x" v="89662.1313"/>
     <tag k="local_y" v="43147.8744"/>
     <tag k="ele" v="43.2791"/>
   </node>
-  <node id="2231" lat="35.62596750034" lon="139.78149331184">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="2231" lat="35.62596750082" lon="139.7814933115">
     <tag k="local_x" v="89659.954"/>
     <tag k="local_y" v="43147.5727"/>
     <tag k="ele" v="43.3074"/>
   </node>
-  <node id="2232" lat="35.62595658338" lon="139.78147230984">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="2232" lat="35.62595658386" lon="139.7814723095">
     <tag k="local_x" v="89658.0371"/>
     <tag k="local_y" v="43146.3854"/>
     <tag k="ele" v="43.2897"/>
   </node>
-  <node id="2233" lat="35.62594145176" lon="139.78145962177">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="2233" lat="35.62594145224" lon="139.78145962143">
     <tag k="local_x" v="89656.8673"/>
     <tag k="local_y" v="43144.7213"/>
     <tag k="ele" v="43.2686"/>
   </node>
-  <node id="2234" lat="35.62591739363" lon="139.78145130845">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="2234" lat="35.62591739411" lon="139.78145130811">
     <tag k="local_x" v="89656.0814"/>
     <tag k="local_y" v="43142.0622"/>
     <tag k="ele" v="43.2499"/>
   </node>
-  <node id="2238" lat="35.6258921275" lon="139.78145396997">
-    <tag k="mgrs_code" v="54SUE896431"/>
+  <node id="2238" lat="35.62589212798" lon="139.78145396963">
     <tag k="local_x" v="89656.2877"/>
     <tag k="local_y" v="43139.2568"/>
     <tag k="ele" v="43.2197"/>
   </node>
-  <node id="2243" lat="35.62585958307" lon="139.7814570953">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89656.526"/>
-    <tag k="local_y" v="43135.6436"/>
-    <tag k="ele" v="43.219"/>
-  </node>
-  <node id="2244" lat="35.62585117599" lon="139.78145862972">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89656.6534"/>
-    <tag k="local_y" v="43134.7094"/>
-    <tag k="ele" v="43.2188"/>
-  </node>
-  <node id="2245" lat="35.62584278035" lon="139.7814602258">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89656.7864"/>
-    <tag k="local_y" v="43133.7764"/>
-    <tag k="ele" v="43.2186"/>
-  </node>
-  <node id="2246" lat="35.62583436848" lon="139.78146173267">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89656.9113"/>
-    <tag k="local_y" v="43132.8417"/>
-    <tag k="ele" v="43.2184"/>
-  </node>
-  <node id="2247" lat="35.62582595375" lon="139.78146322413">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89657.0348"/>
-    <tag k="local_y" v="43131.9067"/>
+  <node id="2247" lat="35.62585117239" lon="139.78146063257">
+    <tag k="local_x" v="89656.8348"/>
+    <tag k="local_y" v="43134.7067"/>
     <tag k="ele" v="43.2181"/>
   </node>
-  <node id="2248" lat="35.62581745947" lon="139.78146407081">
-    <tag k="mgrs_code" v="54SUE896431"/>
-    <tag k="local_x" v="89657.0998"/>
-    <tag k="local_y" v="43130.9636"/>
+  <node id="2248" lat="35.62584267811" lon="139.78146147925">
+    <tag k="local_x" v="89656.8998"/>
+    <tag k="local_y" v="43133.7636"/>
     <tag k="ele" v="43.2177"/>
+  </node>
+  <node id="2250" lat="35.62634400098" lon="139.78106061302">
+    <tag k="local_x" v="89621.2873"/>
+    <tag k="local_y" v="43189.8181"/>
+    <tag k="ele" v="43.148"/>
+  </node>
+  <node id="2251" lat="35.62628495869" lon="139.78110879195">
+    <tag k="local_x" v="89625.5691"/>
+    <tag k="local_y" v="43183.2153"/>
+    <tag k="ele" v="43.148"/>
+  </node>
+  <node id="2257" lat="35.62612359788" lon="139.78141286327">
+    <tag k="local_x" v="89652.8833"/>
+    <tag k="local_y" v="43164.9766"/>
+    <tag k="ele" v="43.148"/>
+  </node>
+  <node id="2258" lat="35.6260619749" lon="139.78138366412">
+    <tag k="local_x" v="89650.1544"/>
+    <tag k="local_y" v="43158.1744"/>
+    <tag k="ele" v="42.9783"/>
   </node>
   <way id="1479">
     <nd ref="11"/>
@@ -5133,7 +3295,6 @@
     <nd ref="1123"/>
     <nd ref="1117"/>
     <nd ref="1127"/>
-    <nd ref="1121"/>
     <nd ref="1126"/>
     <nd ref="16"/>
     <nd ref="1128"/>
@@ -5149,7 +3310,234 @@
     <tag k="type" v="line_thin"/>
     <tag k="subtype" v="solid"/>
   </way>
-  <way id="1480">
+  <way id="1481">
+    <nd ref="8"/>
+    <nd ref="1166"/>
+    <nd ref="593"/>
+    <nd ref="1167"/>
+    <nd ref="1165"/>
+    <nd ref="594"/>
+    <nd ref="592"/>
+    <nd ref="1164"/>
+    <nd ref="1323"/>
+    <nd ref="15"/>
+    <nd ref="1168"/>
+    <nd ref="1324"/>
+    <nd ref="1169"/>
+    <nd ref="1172"/>
+    <nd ref="1170"/>
+    <nd ref="1171"/>
+    <nd ref="17"/>
+    <nd ref="1173"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="1888">
+    <nd ref="1847"/>
+    <nd ref="1850"/>
+    <nd ref="1852"/>
+    <nd ref="1854"/>
+    <nd ref="1856"/>
+    <nd ref="1861"/>
+    <nd ref="1862"/>
+    <nd ref="1864"/>
+    <nd ref="1866"/>
+    <nd ref="1868"/>
+    <nd ref="1870"/>
+    <nd ref="1877"/>
+    <nd ref="1879"/>
+    <nd ref="1881"/>
+    <nd ref="1883"/>
+    <nd ref="1885"/>
+    <nd ref="1887"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="2249">
+    <nd ref="1887"/>
+    <nd ref="1889"/>
+    <nd ref="1891"/>
+    <nd ref="1893"/>
+    <nd ref="1895"/>
+    <nd ref="1903"/>
+    <nd ref="1904"/>
+    <nd ref="1910"/>
+    <nd ref="1915"/>
+    <nd ref="1921"/>
+    <nd ref="1926"/>
+    <nd ref="1930"/>
+    <nd ref="1931"/>
+    <nd ref="1932"/>
+    <nd ref="1933"/>
+    <nd ref="1934"/>
+    <nd ref="1936"/>
+    <nd ref="1938"/>
+    <nd ref="1939"/>
+    <nd ref="1940"/>
+    <nd ref="1941"/>
+    <nd ref="1946"/>
+    <nd ref="1947"/>
+    <nd ref="1948"/>
+    <nd ref="1949"/>
+    <nd ref="1954"/>
+    <nd ref="1960"/>
+    <nd ref="1962"/>
+    <nd ref="1970"/>
+    <nd ref="1976"/>
+    <nd ref="1977"/>
+    <nd ref="1980"/>
+    <nd ref="1986"/>
+    <nd ref="1987"/>
+    <nd ref="1988"/>
+    <nd ref="1989"/>
+    <nd ref="1990"/>
+    <nd ref="1991"/>
+    <nd ref="1992"/>
+    <nd ref="1993"/>
+    <nd ref="1997"/>
+    <nd ref="1999"/>
+    <nd ref="2001"/>
+    <nd ref="2006"/>
+    <nd ref="2008"/>
+    <nd ref="2010"/>
+    <nd ref="2012"/>
+    <nd ref="2014"/>
+    <nd ref="2016"/>
+    <nd ref="2018"/>
+    <nd ref="2020"/>
+    <nd ref="2021"/>
+    <nd ref="2023"/>
+    <nd ref="2025"/>
+    <nd ref="2026"/>
+    <nd ref="2030"/>
+    <nd ref="2036"/>
+    <nd ref="2038"/>
+    <nd ref="2039"/>
+    <nd ref="2040"/>
+    <nd ref="2041"/>
+    <nd ref="2042"/>
+    <nd ref="2043"/>
+    <nd ref="2050"/>
+    <nd ref="2051"/>
+    <nd ref="2052"/>
+    <nd ref="2061"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="9100">
+    <nd ref="2061"/>
+    <nd ref="2062"/>
+    <nd ref="2063"/>
+    <nd ref="2064"/>
+    <nd ref="2065"/>
+    <nd ref="2066"/>
+    <nd ref="2067"/>
+    <nd ref="2068"/>
+    <nd ref="2069"/>
+    <nd ref="2070"/>
+    <nd ref="2076"/>
+    <nd ref="2077"/>
+    <nd ref="2078"/>
+    <nd ref="2079"/>
+    <nd ref="2080"/>
+    <nd ref="2081"/>
+    <nd ref="2082"/>
+    <nd ref="2083"/>
+    <nd ref="2084"/>
+    <nd ref="2085"/>
+    <nd ref="2094"/>
+    <nd ref="2095"/>
+    <nd ref="2096"/>
+    <nd ref="2097"/>
+    <nd ref="2098"/>
+    <nd ref="2099"/>
+    <nd ref="2100"/>
+    <nd ref="2101"/>
+    <nd ref="2102"/>
+    <nd ref="2103"/>
+    <nd ref="2104"/>
+    <nd ref="2105"/>
+    <nd ref="2106"/>
+    <nd ref="2107"/>
+    <nd ref="2108"/>
+    <nd ref="2109"/>
+    <nd ref="2110"/>
+    <nd ref="2115"/>
+    <nd ref="2116"/>
+    <nd ref="2117"/>
+    <nd ref="2118"/>
+    <nd ref="2119"/>
+    <nd ref="2122"/>
+    <nd ref="2126"/>
+    <nd ref="2127"/>
+    <nd ref="2130"/>
+    <nd ref="2139"/>
+    <nd ref="2141"/>
+    <nd ref="2142"/>
+    <nd ref="2143"/>
+    <nd ref="2144"/>
+    <nd ref="2147"/>
+    <nd ref="2149"/>
+    <nd ref="2151"/>
+    <nd ref="2152"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="9101">
+    <nd ref="2152"/>
+    <nd ref="2153"/>
+    <nd ref="2155"/>
+    <nd ref="2157"/>
+    <nd ref="2158"/>
+    <nd ref="2159"/>
+    <nd ref="2165"/>
+    <nd ref="2168"/>
+    <nd ref="2169"/>
+    <nd ref="2170"/>
+    <nd ref="2173"/>
+    <nd ref="2174"/>
+    <nd ref="2175"/>
+    <nd ref="2176"/>
+    <nd ref="2181"/>
+    <nd ref="2184"/>
+    <nd ref="2185"/>
+    <nd ref="2186"/>
+    <nd ref="2187"/>
+    <nd ref="2188"/>
+    <nd ref="2189"/>
+    <nd ref="2190"/>
+    <nd ref="2191"/>
+    <nd ref="2193"/>
+    <nd ref="2194"/>
+    <nd ref="2195"/>
+    <nd ref="2196"/>
+    <nd ref="2197"/>
+    <nd ref="2198"/>
+    <nd ref="2199"/>
+    <nd ref="2200"/>
+    <nd ref="2202"/>
+    <nd ref="2203"/>
+    <nd ref="2205"/>
+    <nd ref="2209"/>
+    <nd ref="2210"/>
+    <nd ref="2218"/>
+    <nd ref="2219"/>
+    <nd ref="2221"/>
+    <nd ref="2222"/>
+    <nd ref="2223"/>
+    <nd ref="2225"/>
+    <nd ref="2231"/>
+    <nd ref="2232"/>
+    <nd ref="2233"/>
+    <nd ref="2234"/>
+    <nd ref="2238"/>
+    <nd ref="2247"/>
+    <nd ref="2248"/>
+    <nd ref="1847"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="2252">
     <nd ref="1136"/>
     <nd ref="1137"/>
     <nd ref="1138"/>
@@ -5183,7 +3571,6 @@
     <nd ref="464"/>
     <nd ref="997"/>
     <nd ref="22"/>
-    <nd ref="1000"/>
     <nd ref="999"/>
     <nd ref="1001"/>
     <nd ref="1002"/>
@@ -5198,16 +3585,11 @@
     <nd ref="1011"/>
     <nd ref="1019"/>
     <nd ref="24"/>
-    <nd ref="1014"/>
     <nd ref="466"/>
-    <nd ref="1015"/>
     <nd ref="465"/>
     <nd ref="1016"/>
     <nd ref="467"/>
-    <nd ref="1017"/>
     <nd ref="26"/>
-    <nd ref="1018"/>
-    <nd ref="1012"/>
     <nd ref="1013"/>
     <nd ref="1020"/>
     <nd ref="1021"/>
@@ -5220,30 +3602,20 @@
     <nd ref="1028"/>
     <nd ref="1029"/>
     <nd ref="28"/>
-    <nd ref="1033"/>
     <nd ref="1030"/>
-    <nd ref="1032"/>
     <nd ref="470"/>
-    <nd ref="1034"/>
-    <nd ref="1031"/>
     <nd ref="1035"/>
     <nd ref="468"/>
     <nd ref="1036"/>
     <nd ref="469"/>
     <nd ref="39"/>
     <nd ref="1037"/>
-    <nd ref="472"/>
     <nd ref="1039"/>
-    <nd ref="471"/>
     <nd ref="1038"/>
     <nd ref="473"/>
-    <nd ref="1040"/>
     <nd ref="30"/>
-    <nd ref="1041"/>
     <nd ref="475"/>
-    <nd ref="1044"/>
     <nd ref="1043"/>
-    <nd ref="1042"/>
     <nd ref="474"/>
     <nd ref="1045"/>
     <nd ref="476"/>
@@ -5251,177 +3623,11 @@
     <nd ref="40"/>
     <nd ref="478"/>
     <nd ref="477"/>
-    <nd ref="479"/>
-    <nd ref="1048"/>
-    <nd ref="41"/>
-    <nd ref="1047"/>
-    <nd ref="483"/>
-    <nd ref="1049"/>
-    <nd ref="481"/>
-    <nd ref="1050"/>
-    <nd ref="484"/>
-    <nd ref="1051"/>
-    <nd ref="480"/>
-    <nd ref="1052"/>
-    <nd ref="485"/>
-    <nd ref="1053"/>
-    <nd ref="1057"/>
-    <nd ref="482"/>
-    <nd ref="1054"/>
-    <nd ref="486"/>
-    <nd ref="1055"/>
-    <nd ref="32"/>
-    <nd ref="1056"/>
-    <nd ref="487"/>
-    <nd ref="490"/>
-    <nd ref="1058"/>
-    <nd ref="1059"/>
-    <nd ref="488"/>
-    <nd ref="489"/>
-    <nd ref="1060"/>
-    <nd ref="1061"/>
-    <nd ref="42"/>
-    <nd ref="1062"/>
-    <nd ref="1063"/>
-    <nd ref="492"/>
-    <nd ref="1064"/>
-    <nd ref="491"/>
-    <nd ref="1065"/>
-    <nd ref="493"/>
-    <nd ref="1066"/>
-    <nd ref="43"/>
-    <nd ref="1067"/>
-    <nd ref="495"/>
-    <nd ref="1068"/>
-    <nd ref="494"/>
-    <nd ref="1069"/>
-    <nd ref="496"/>
-    <nd ref="47"/>
-    <nd ref="1070"/>
-    <nd ref="499"/>
-    <nd ref="1071"/>
-    <nd ref="497"/>
-    <nd ref="1073"/>
-    <nd ref="1072"/>
-    <nd ref="498"/>
-    <nd ref="1074"/>
-    <nd ref="48"/>
-    <nd ref="1075"/>
-    <nd ref="501"/>
-    <nd ref="500"/>
-    <nd ref="1076"/>
-    <nd ref="502"/>
-    <nd ref="50"/>
-    <nd ref="1077"/>
-    <nd ref="504"/>
-    <nd ref="1078"/>
-    <nd ref="503"/>
-    <nd ref="1079"/>
-    <nd ref="1080"/>
-    <nd ref="505"/>
-    <nd ref="1081"/>
-    <nd ref="49"/>
-    <nd ref="1082"/>
-    <nd ref="507"/>
-    <nd ref="1083"/>
-    <nd ref="506"/>
-    <nd ref="1084"/>
-    <nd ref="508"/>
-    <nd ref="1085"/>
-    <nd ref="44"/>
-    <nd ref="1090"/>
-    <nd ref="1087"/>
-    <nd ref="1086"/>
-    <nd ref="1088"/>
-    <nd ref="1089"/>
-    <nd ref="510"/>
-    <nd ref="1091"/>
-    <nd ref="509"/>
-    <nd ref="1092"/>
-    <nd ref="511"/>
-    <nd ref="1093"/>
-    <nd ref="1094"/>
-    <nd ref="45"/>
-    <nd ref="1095"/>
-    <nd ref="1096"/>
-    <nd ref="515"/>
-    <nd ref="1097"/>
-    <nd ref="1098"/>
-    <nd ref="513"/>
-    <nd ref="517"/>
-    <nd ref="512"/>
-    <nd ref="1100"/>
-    <nd ref="514"/>
-    <nd ref="1099"/>
-    <nd ref="516"/>
-    <nd ref="1101"/>
-    <nd ref="1102"/>
-    <nd ref="46"/>
-    <nd ref="1104"/>
-    <nd ref="1103"/>
-    <nd ref="519"/>
-    <nd ref="1105"/>
-    <nd ref="518"/>
-    <nd ref="520"/>
-    <nd ref="1106"/>
-    <nd ref="52"/>
-    <nd ref="1107"/>
-    <nd ref="522"/>
-    <nd ref="1108"/>
-    <nd ref="521"/>
-    <nd ref="53"/>
-    <nd ref="523"/>
-    <nd ref="1109"/>
-    <nd ref="54"/>
-    <nd ref="526"/>
-    <nd ref="1110"/>
-    <nd ref="524"/>
-    <nd ref="525"/>
-    <nd ref="34"/>
-    <nd ref="1114"/>
-    <nd ref="529"/>
-    <nd ref="1113"/>
-    <nd ref="527"/>
-    <nd ref="1111"/>
-    <nd ref="528"/>
-    <nd ref="1112"/>
-    <nd ref="36"/>
-    <nd ref="1154"/>
-    <nd ref="532"/>
-    <nd ref="1155"/>
-    <nd ref="530"/>
-    <nd ref="1156"/>
-    <nd ref="531"/>
-    <nd ref="1157"/>
-    <nd ref="11"/>
+    <nd ref="2250"/>
     <tag k="type" v="line_thin"/>
     <tag k="subtype" v="solid"/>
   </way>
-  <way id="1481">
-    <nd ref="8"/>
-    <nd ref="1166"/>
-    <nd ref="593"/>
-    <nd ref="1322"/>
-    <nd ref="1167"/>
-    <nd ref="9"/>
-    <nd ref="1165"/>
-    <nd ref="594"/>
-    <nd ref="592"/>
-    <nd ref="1164"/>
-    <nd ref="1323"/>
-    <nd ref="15"/>
-    <nd ref="1168"/>
-    <nd ref="1324"/>
-    <nd ref="1169"/>
-    <nd ref="1172"/>
-    <nd ref="1170"/>
-    <nd ref="1171"/>
-    <nd ref="17"/>
-    <nd ref="1173"/>
-    <tag k="type" v="line_thin"/>
-    <tag k="subtype" v="solid"/>
-  </way>
-  <way id="1482">
+  <way id="2254">
     <nd ref="1173"/>
     <nd ref="1174"/>
     <nd ref="1175"/>
@@ -5437,15 +3643,10 @@
     <nd ref="1185"/>
     <nd ref="1186"/>
     <nd ref="1187"/>
-    <nd ref="1188"/>
     <nd ref="19"/>
-    <nd ref="1189"/>
     <nd ref="534"/>
-    <nd ref="1190"/>
     <nd ref="533"/>
-    <nd ref="1191"/>
     <nd ref="535"/>
-    <nd ref="1192"/>
     <nd ref="21"/>
     <nd ref="1193"/>
     <nd ref="1194"/>
@@ -5503,35 +3704,173 @@
     <nd ref="547"/>
     <nd ref="1232"/>
     <nd ref="545"/>
-    <nd ref="1233"/>
     <nd ref="546"/>
-    <nd ref="1234"/>
     <nd ref="29"/>
     <nd ref="1235"/>
     <nd ref="549"/>
-    <nd ref="1236"/>
     <nd ref="1237"/>
     <nd ref="548"/>
     <nd ref="1239"/>
+    <nd ref="2251"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="2259">
+    <nd ref="2250"/>
+    <nd ref="479"/>
+    <nd ref="1048"/>
+    <nd ref="41"/>
+    <nd ref="1047"/>
+    <nd ref="483"/>
+    <nd ref="1049"/>
+    <nd ref="481"/>
+    <nd ref="1050"/>
+    <nd ref="484"/>
+    <nd ref="1051"/>
+    <nd ref="480"/>
+    <nd ref="1052"/>
+    <nd ref="485"/>
+    <nd ref="1057"/>
+    <nd ref="1054"/>
+    <nd ref="486"/>
+    <nd ref="1055"/>
+    <nd ref="32"/>
+    <nd ref="1056"/>
+    <nd ref="487"/>
+    <nd ref="490"/>
+    <nd ref="1058"/>
+    <nd ref="1059"/>
+    <nd ref="488"/>
+    <nd ref="489"/>
+    <nd ref="1060"/>
+    <nd ref="1061"/>
+    <nd ref="42"/>
+    <nd ref="1062"/>
+    <nd ref="1063"/>
+    <nd ref="492"/>
+    <nd ref="1064"/>
+    <nd ref="491"/>
+    <nd ref="1065"/>
+    <nd ref="493"/>
+    <nd ref="1066"/>
+    <nd ref="43"/>
+    <nd ref="1067"/>
+    <nd ref="495"/>
+    <nd ref="1068"/>
+    <nd ref="494"/>
+    <nd ref="1069"/>
+    <nd ref="496"/>
+    <nd ref="47"/>
+    <nd ref="1070"/>
+    <nd ref="499"/>
+    <nd ref="1071"/>
+    <nd ref="497"/>
+    <nd ref="1073"/>
+    <nd ref="1072"/>
+    <nd ref="498"/>
+    <nd ref="1074"/>
+    <nd ref="48"/>
+    <nd ref="501"/>
+    <nd ref="500"/>
+    <nd ref="502"/>
+    <nd ref="1077"/>
+    <nd ref="504"/>
+    <nd ref="1078"/>
+    <nd ref="2257"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="2260">
+    <nd ref="2257"/>
+    <nd ref="503"/>
+    <nd ref="1079"/>
+    <nd ref="1080"/>
+    <nd ref="505"/>
+    <nd ref="1081"/>
+    <nd ref="1082"/>
+    <nd ref="1083"/>
+    <nd ref="1084"/>
+    <nd ref="508"/>
+    <nd ref="44"/>
+    <nd ref="1090"/>
+    <nd ref="1087"/>
+    <nd ref="1086"/>
+    <nd ref="1088"/>
+    <nd ref="1089"/>
+    <nd ref="510"/>
+    <nd ref="1091"/>
+    <nd ref="509"/>
+    <nd ref="1092"/>
+    <nd ref="511"/>
+    <nd ref="1093"/>
+    <nd ref="1094"/>
+    <nd ref="45"/>
+    <nd ref="1095"/>
+    <nd ref="1096"/>
+    <nd ref="515"/>
+    <nd ref="1097"/>
+    <nd ref="1098"/>
+    <nd ref="513"/>
+    <nd ref="517"/>
+    <nd ref="512"/>
+    <nd ref="1100"/>
+    <nd ref="514"/>
+    <nd ref="1099"/>
+    <nd ref="516"/>
+    <nd ref="1101"/>
+    <nd ref="1102"/>
+    <nd ref="46"/>
+    <nd ref="1104"/>
+    <nd ref="1103"/>
+    <nd ref="519"/>
+    <nd ref="1105"/>
+    <nd ref="518"/>
+    <nd ref="520"/>
+    <nd ref="1106"/>
+    <nd ref="52"/>
+    <nd ref="1107"/>
+    <nd ref="522"/>
+    <nd ref="1108"/>
+    <nd ref="521"/>
+    <nd ref="53"/>
+    <nd ref="523"/>
+    <nd ref="1109"/>
+    <nd ref="54"/>
+    <nd ref="526"/>
+    <nd ref="1110"/>
+    <nd ref="524"/>
+    <nd ref="525"/>
+    <nd ref="34"/>
+    <nd ref="1114"/>
+    <nd ref="1113"/>
+    <nd ref="1111"/>
+    <nd ref="1112"/>
+    <nd ref="36"/>
+    <nd ref="1154"/>
+    <nd ref="532"/>
+    <nd ref="1155"/>
+    <nd ref="530"/>
+    <nd ref="1156"/>
+    <nd ref="531"/>
+    <nd ref="1157"/>
+    <nd ref="11"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="2261">
+    <nd ref="2251"/>
     <nd ref="1238"/>
     <nd ref="550"/>
     <nd ref="1240"/>
-    <nd ref="1241"/>
     <nd ref="1242"/>
-    <nd ref="31"/>
     <nd ref="1243"/>
-    <nd ref="1244"/>
     <nd ref="1245"/>
-    <nd ref="1246"/>
     <nd ref="552"/>
-    <nd ref="1247"/>
     <nd ref="1248"/>
-    <nd ref="551"/>
     <nd ref="1249"/>
     <nd ref="553"/>
     <nd ref="1250"/>
     <nd ref="66"/>
-    <nd ref="1251"/>
     <nd ref="1252"/>
     <nd ref="554"/>
     <nd ref="1253"/>
@@ -5550,17 +3889,11 @@
     <nd ref="1262"/>
     <nd ref="1263"/>
     <nd ref="57"/>
-    <nd ref="1264"/>
     <nd ref="1265"/>
-    <nd ref="559"/>
     <nd ref="1266"/>
-    <nd ref="1267"/>
     <nd ref="558"/>
-    <nd ref="1268"/>
-    <nd ref="560"/>
     <nd ref="1269"/>
     <nd ref="64"/>
-    <nd ref="1270"/>
     <nd ref="562"/>
     <nd ref="1271"/>
     <nd ref="1272"/>
@@ -5589,6 +3922,12 @@
     <nd ref="572"/>
     <nd ref="61"/>
     <nd ref="574"/>
+    <nd ref="2258"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="2262">
+    <nd ref="2258"/>
     <nd ref="573"/>
     <nd ref="575"/>
     <nd ref="1282"/>
@@ -5604,16 +3943,11 @@
     <nd ref="1287"/>
     <nd ref="1298"/>
     <nd ref="578"/>
-    <nd ref="1290"/>
     <nd ref="1296"/>
-    <nd ref="1288"/>
     <nd ref="1291"/>
-    <nd ref="1297"/>
     <nd ref="67"/>
     <nd ref="1292"/>
-    <nd ref="1294"/>
     <nd ref="1289"/>
-    <nd ref="1295"/>
     <nd ref="1293"/>
     <nd ref="579"/>
     <nd ref="1300"/>
@@ -5625,10 +3959,8 @@
     <nd ref="580"/>
     <nd ref="1305"/>
     <nd ref="1306"/>
-    <nd ref="1313"/>
     <nd ref="68"/>
     <nd ref="1307"/>
-    <nd ref="1308"/>
     <nd ref="1314"/>
     <nd ref="584"/>
     <nd ref="1309"/>
@@ -5665,360 +3997,43 @@
     <tag k="type" v="line_thin"/>
     <tag k="subtype" v="solid"/>
   </way>
-  <way id="1888">
-    <nd ref="1847"/>
-    <nd ref="1848"/>
-    <nd ref="1849"/>
-    <nd ref="1850"/>
-    <nd ref="1851"/>
-    <nd ref="1852"/>
-    <nd ref="1853"/>
-    <nd ref="1854"/>
-    <nd ref="1855"/>
-    <nd ref="1856"/>
-    <nd ref="1857"/>
-    <nd ref="1858"/>
-    <nd ref="1859"/>
-    <nd ref="1860"/>
-    <nd ref="1861"/>
-    <nd ref="1862"/>
-    <nd ref="1863"/>
-    <nd ref="1864"/>
-    <nd ref="1866"/>
-    <nd ref="1867"/>
-    <nd ref="1868"/>
-    <nd ref="1869"/>
-    <nd ref="1870"/>
-    <nd ref="1871"/>
-    <nd ref="1872"/>
-    <nd ref="1873"/>
-    <nd ref="1874"/>
-    <nd ref="1875"/>
-    <nd ref="1876"/>
-    <nd ref="1877"/>
-    <nd ref="1878"/>
-    <nd ref="1879"/>
-    <nd ref="1880"/>
-    <nd ref="1881"/>
-    <nd ref="1882"/>
-    <nd ref="1883"/>
-    <nd ref="1884"/>
-    <nd ref="1885"/>
-    <nd ref="1886"/>
-    <nd ref="1887"/>
-    <tag k="type" v="line_thin"/>
-    <tag k="subtype" v="solid"/>
-  </way>
-  <way id="2249">
-    <nd ref="1887"/>
-    <nd ref="1889"/>
-    <nd ref="1890"/>
-    <nd ref="1891"/>
-    <nd ref="1892"/>
-    <nd ref="1893"/>
-    <nd ref="1894"/>
-    <nd ref="1895"/>
-    <nd ref="1896"/>
-    <nd ref="1897"/>
-    <nd ref="1898"/>
-    <nd ref="1899"/>
-    <nd ref="1900"/>
-    <nd ref="1901"/>
-    <nd ref="1902"/>
-    <nd ref="1903"/>
-    <nd ref="1904"/>
-    <nd ref="1905"/>
-    <nd ref="1906"/>
-    <nd ref="1907"/>
-    <nd ref="1908"/>
-    <nd ref="1909"/>
-    <nd ref="1910"/>
-    <nd ref="1911"/>
-    <nd ref="1912"/>
-    <nd ref="1913"/>
-    <nd ref="1914"/>
-    <nd ref="1915"/>
-    <nd ref="1916"/>
-    <nd ref="1917"/>
-    <nd ref="1918"/>
-    <nd ref="1919"/>
-    <nd ref="1920"/>
-    <nd ref="1921"/>
-    <nd ref="1922"/>
-    <nd ref="1923"/>
-    <nd ref="1924"/>
-    <nd ref="1925"/>
-    <nd ref="1926"/>
-    <nd ref="1927"/>
-    <nd ref="1928"/>
-    <nd ref="1929"/>
-    <nd ref="1930"/>
-    <nd ref="1931"/>
-    <nd ref="1932"/>
-    <nd ref="1933"/>
-    <nd ref="1934"/>
-    <nd ref="1935"/>
-    <nd ref="1936"/>
-    <nd ref="1937"/>
-    <nd ref="1938"/>
-    <nd ref="1939"/>
-    <nd ref="1940"/>
-    <nd ref="1941"/>
-    <nd ref="1946"/>
-    <nd ref="1947"/>
-    <nd ref="1948"/>
-    <nd ref="1949"/>
-    <nd ref="1950"/>
-    <nd ref="1954"/>
-    <nd ref="1955"/>
-    <nd ref="1956"/>
-    <nd ref="1957"/>
-    <nd ref="1958"/>
-    <nd ref="1959"/>
-    <nd ref="1960"/>
-    <nd ref="1961"/>
-    <nd ref="1962"/>
-    <nd ref="1963"/>
-    <nd ref="1964"/>
-    <nd ref="1965"/>
-    <nd ref="1966"/>
-    <nd ref="1967"/>
-    <nd ref="1968"/>
-    <nd ref="1969"/>
-    <nd ref="1970"/>
-    <nd ref="1971"/>
-    <nd ref="1972"/>
-    <nd ref="1973"/>
-    <nd ref="1974"/>
-    <nd ref="1975"/>
-    <nd ref="1976"/>
-    <nd ref="1977"/>
-    <nd ref="1980"/>
-    <nd ref="1986"/>
-    <nd ref="1987"/>
-    <nd ref="1988"/>
-    <nd ref="1989"/>
-    <nd ref="1990"/>
-    <nd ref="1991"/>
-    <nd ref="1992"/>
-    <nd ref="1993"/>
-    <nd ref="1994"/>
-    <nd ref="1995"/>
-    <nd ref="1996"/>
-    <nd ref="1997"/>
-    <nd ref="1998"/>
-    <nd ref="1999"/>
-    <nd ref="2000"/>
-    <nd ref="2001"/>
-    <nd ref="2002"/>
-    <nd ref="2003"/>
-    <nd ref="2004"/>
-    <nd ref="2005"/>
-    <nd ref="2006"/>
-    <nd ref="2007"/>
-    <nd ref="2008"/>
-    <nd ref="2009"/>
-    <nd ref="2010"/>
-    <nd ref="2011"/>
-    <nd ref="2012"/>
-    <nd ref="2013"/>
-    <nd ref="2014"/>
-    <nd ref="2015"/>
-    <nd ref="2016"/>
-    <nd ref="2017"/>
-    <nd ref="2018"/>
-    <nd ref="2019"/>
-    <nd ref="2020"/>
-    <nd ref="2021"/>
-    <nd ref="2022"/>
-    <nd ref="2023"/>
-    <nd ref="2024"/>
-    <nd ref="2025"/>
-    <nd ref="2026"/>
-    <nd ref="2027"/>
-    <nd ref="2028"/>
-    <nd ref="2029"/>
-    <nd ref="2030"/>
-    <nd ref="2036"/>
-    <nd ref="2038"/>
-    <nd ref="2039"/>
-    <nd ref="2040"/>
-    <nd ref="2041"/>
-    <nd ref="2042"/>
-    <nd ref="2043"/>
-    <nd ref="2050"/>
-    <nd ref="2051"/>
-    <nd ref="2052"/>
-    <nd ref="2055"/>
-    <nd ref="2056"/>
-    <nd ref="2057"/>
-    <nd ref="2058"/>
-    <nd ref="2059"/>
-    <nd ref="2060"/>
-    <nd ref="2061"/>
-    <nd ref="2062"/>
-    <nd ref="2063"/>
-    <nd ref="2064"/>
-    <nd ref="2065"/>
-    <nd ref="2066"/>
-    <nd ref="2067"/>
-    <nd ref="2068"/>
-    <nd ref="2069"/>
-    <nd ref="2070"/>
-    <nd ref="2071"/>
-    <nd ref="2072"/>
-    <nd ref="2073"/>
-    <nd ref="2074"/>
-    <nd ref="2075"/>
-    <nd ref="2076"/>
-    <nd ref="2077"/>
-    <nd ref="2078"/>
-    <nd ref="2079"/>
-    <nd ref="2080"/>
-    <nd ref="2081"/>
-    <nd ref="2082"/>
-    <nd ref="2083"/>
-    <nd ref="2084"/>
-    <nd ref="2085"/>
-    <nd ref="2086"/>
-    <nd ref="2087"/>
-    <nd ref="2088"/>
-    <nd ref="2089"/>
-    <nd ref="2090"/>
-    <nd ref="2091"/>
-    <nd ref="2092"/>
-    <nd ref="2093"/>
-    <nd ref="2094"/>
-    <nd ref="2095"/>
-    <nd ref="2096"/>
-    <nd ref="2097"/>
-    <nd ref="2098"/>
-    <nd ref="2099"/>
-    <nd ref="2100"/>
-    <nd ref="2101"/>
-    <nd ref="2102"/>
-    <nd ref="2103"/>
-    <nd ref="2104"/>
-    <nd ref="2105"/>
-    <nd ref="2106"/>
-    <nd ref="2107"/>
-    <nd ref="2108"/>
-    <nd ref="2109"/>
-    <nd ref="2110"/>
-    <nd ref="2111"/>
-    <nd ref="2112"/>
-    <nd ref="2113"/>
-    <nd ref="2114"/>
-    <nd ref="2115"/>
-    <nd ref="2116"/>
-    <nd ref="2117"/>
-    <nd ref="2118"/>
-    <nd ref="2119"/>
-    <nd ref="2120"/>
-    <nd ref="2121"/>
-    <nd ref="2122"/>
-    <nd ref="2123"/>
-    <nd ref="2124"/>
-    <nd ref="2125"/>
-    <nd ref="2126"/>
-    <nd ref="2127"/>
-    <nd ref="2130"/>
-    <nd ref="2139"/>
-    <nd ref="2141"/>
-    <nd ref="2142"/>
-    <nd ref="2143"/>
-    <nd ref="2144"/>
-    <nd ref="2147"/>
-    <nd ref="2148"/>
-    <nd ref="2149"/>
-    <nd ref="2150"/>
-    <nd ref="2151"/>
-    <nd ref="2152"/>
-    <nd ref="2153"/>
-    <nd ref="2154"/>
-    <nd ref="2155"/>
-    <nd ref="2156"/>
-    <nd ref="2157"/>
-    <nd ref="2158"/>
-    <nd ref="2159"/>
-    <nd ref="2165"/>
-    <nd ref="2168"/>
-    <nd ref="2169"/>
-    <nd ref="2170"/>
-    <nd ref="2173"/>
-    <nd ref="2174"/>
-    <nd ref="2175"/>
-    <nd ref="2176"/>
-    <nd ref="2181"/>
-    <nd ref="2184"/>
-    <nd ref="2185"/>
-    <nd ref="2186"/>
-    <nd ref="2187"/>
-    <nd ref="2188"/>
-    <nd ref="2189"/>
-    <nd ref="2190"/>
-    <nd ref="2191"/>
-    <nd ref="2192"/>
-    <nd ref="2193"/>
-    <nd ref="2194"/>
-    <nd ref="2195"/>
-    <nd ref="2196"/>
-    <nd ref="2197"/>
-    <nd ref="2198"/>
-    <nd ref="2199"/>
-    <nd ref="2200"/>
-    <nd ref="2201"/>
-    <nd ref="2202"/>
-    <nd ref="2203"/>
-    <nd ref="2204"/>
-    <nd ref="2205"/>
-    <nd ref="2206"/>
-    <nd ref="2207"/>
-    <nd ref="2208"/>
-    <nd ref="2209"/>
-    <nd ref="2210"/>
-    <nd ref="2211"/>
-    <nd ref="2212"/>
-    <nd ref="2213"/>
-    <nd ref="2214"/>
-    <nd ref="2218"/>
-    <nd ref="2219"/>
-    <nd ref="2221"/>
-    <nd ref="2222"/>
-    <nd ref="2223"/>
-    <nd ref="2225"/>
-    <nd ref="2231"/>
-    <nd ref="2232"/>
-    <nd ref="2233"/>
-    <nd ref="2234"/>
-    <nd ref="2238"/>
-    <nd ref="2243"/>
-    <nd ref="2244"/>
-    <nd ref="2245"/>
-    <nd ref="2246"/>
-    <nd ref="2247"/>
-    <nd ref="2248"/>
-    <nd ref="1847"/>
-    <tag k="type" v="line_thin"/>
-    <tag k="subtype" v="solid"/>
-  </way>
   <relation id="14">
     <member type="way" role="left" ref="1479"/>
     <member type="way" role="right" ref="1481"/>
     <member type="way" role="centerline" ref="1888"/>
     <tag k="type" v="lanelet"/>
     <tag k="subtype" v="road"/>
-    <tag k="speed_limit" v="40"/>
+    <tag k="speed_limit" v="30"/>
     <tag k="location" v="urban"/>
     <tag k="one_way" v="yes"/>
   </relation>
   <relation id="1483">
-    <member type="way" role="left" ref="1480"/>
-    <member type="way" role="right" ref="1482"/>
+    <member type="way" role="left" ref="2252"/>
+    <member type="way" role="right" ref="2254"/>
     <member type="way" role="centerline" ref="2249"/>
     <tag k="type" v="lanelet"/>
     <tag k="subtype" v="road"/>
-    <tag k="speed_limit" v="40"/>
+    <tag k="speed_limit" v="30"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="yes"/>
+  </relation>
+  <relation id="2256">
+    <member type="way" role="left" ref="2259"/>
+    <member type="way" role="right" ref="2261"/>
+    <member type="way" role="centerline" ref="9100"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road"/>
+    <tag k="speed_limit" v="30"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="yes"/>
+  </relation>
+  <relation id="2263">
+    <member type="way" role="left" ref="2260"/>
+    <member type="way" role="right" ref="2262"/>
+    <member type="way" role="centerline" ref="9101"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road"/>
+    <tag k="speed_limit" v="30"/>
     <tag k="location" v="urban"/>
     <tag k="one_way" v="yes"/>
   </relation>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/d238e0eb-026b-4ae0-aaa8-3641dbf020ae)

before
```
[component_container-13] [31m[ERROR] [1721231036.513720143] [lanelet2_extension]: Fail to expand lanelet. output may be undesired. Lanelet points interval in map data could be too narrow.[0m
```

after
```
[component_container-13] [INFO] [1725666177.927361530] 
```