### PR TITLE
feat(rviz): modify layout

### DIFF
--- a/aichallenge/workspace/src/aichallenge_launch/launch/aichallenge_system.launch.xml
+++ b/aichallenge/workspace/src/aichallenge_launch/launch/aichallenge_system.launch.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <launch>
-    <arg name="rviz_config" default="$(find-pkg-share aichallenge_system_launch)/config/autoware.rviz" description="rviz config"/>
+    <arg name="rviz_config" default="$(find-pkg-share aichallenge_system_launch)/config/debug_sensing.rviz" description="rviz config"/>
     <log message="This is aichallenge_system_launch."/>
     <arg name="simulation" default="false"/>
     <arg name="use_sim_time" default="$(var simulation)"/>

--- a/aichallenge/workspace/src/aichallenge_system/aichallenge_system_launch/config/debug_sensing.rviz
+++ b/aichallenge/workspace/src/aichallenge_system/aichallenge_system_launch/config/debug_sensing.rviz
@@ -226,7 +226,7 @@ Visualization Manager:
               Value: true
               Value Scale: 0.25
             - Class: rviz_plugins/TurnSignal
-              Enabled: true
+              Enabled: false
               Height: 273
               Left: 209
               Name: TurnSignal

--- a/aichallenge/workspace/src/aichallenge_system/aichallenge_system_launch/config/debug_sensing.rviz
+++ b/aichallenge/workspace/src/aichallenge_system/aichallenge_system_launch/config/debug_sensing.rviz
@@ -111,7 +111,7 @@ Visualization Manager:
               Left: 50
               Length: 100
               Name: SteeringAngle
-              Scale: 17
+              Scale: 3
               Text Color: 25; 255; 240
               Top: 50
               Topic:

--- a/aichallenge/workspace/src/aichallenge_system/aichallenge_system_launch/config/debug_sensing.rviz
+++ b/aichallenge/workspace/src/aichallenge_system/aichallenge_system_launch/config/debug_sensing.rviz
@@ -129,7 +129,7 @@ Visualization Manager:
               Length: 100
               Name: ConsoleMeter
               Text Color: 25; 255; 240
-              Top: 50
+              Top: 35
               Topic:
                 Depth: 5
                 Durability Policy: Volatile

--- a/aichallenge/workspace/src/aichallenge_system/aichallenge_system_launch/config/debug_sensing.rviz
+++ b/aichallenge/workspace/src/aichallenge_system/aichallenge_system_launch/config/debug_sensing.rviz
@@ -108,12 +108,12 @@ Visualization Manager:
           Displays:
             - Class: rviz_plugins/SteeringAngle
               Enabled: true
-              Left: 137
-              Length: 273
+              Left: 50
+              Length: 100
               Name: SteeringAngle
               Scale: 17
               Text Color: 25; 255; 240
-              Top: 137
+              Top: 50
               Topic:
                 Depth: 5
                 Durability Policy: Volatile
@@ -125,11 +125,11 @@ Visualization Manager:
               Value height offset: 0
             - Class: rviz_plugins/ConsoleMeter
               Enabled: true
-              Left: 546
-              Length: 273
+              Left: 200
+              Length: 100
               Name: ConsoleMeter
               Text Color: 25; 255; 240
-              Top: 137
+              Top: 50
               Topic:
                 Depth: 5
                 Durability Policy: Volatile
@@ -1796,6 +1796,21 @@ Visualization Manager:
       Plane: XY
       Plane Cell Count: 100
       Reference Frame: viewer
+      Value: true
+    - Alpha: 1
+      Class: rviz_default_plugins/PointStamped
+      Color: 204; 41; 204
+      Enabled: true
+      History Length: 1
+      Name: PointStamped
+      Radius: 1
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        Filter size: 10
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /simple_pure_pursuit_node/debug/markers
       Value: true
   Enabled: true
   Global Options:

--- a/aichallenge/workspace/src/aichallenge_system/aichallenge_system_launch/config/debug_sensing.rviz
+++ b/aichallenge/workspace/src/aichallenge_system/aichallenge_system_launch/config/debug_sensing.rviz
@@ -113,7 +113,7 @@ Visualization Manager:
               Name: SteeringAngle
               Scale: 3
               Text Color: 25; 255; 240
-              Top: 50
+              Top: 30
               Topic:
                 Depth: 5
                 Durability Policy: Volatile


### PR DESCRIPTION
- debug_sensing.rvizをデフォルトで使うようにしました。
- steering angleとvelocityのメーターをノートパソコンで見やすくするように小さくしました。
- steering angleとvelocityのメーターのスケールを見やすくなるように小さくしました。
- 方向器を消去しました。

![image](https://github.com/user-attachments/assets/69ed4e81-e743-4682-9cc6-1cd3347c4db1)

