### PR TITLE
feat(rviz): add odometry marker

### DIFF
--- a/aichallenge/workspace/src/aichallenge_system/aichallenge_system_launch/config/debug_sensing.rviz
+++ b/aichallenge/workspace/src/aichallenge_system/aichallenge_system_launch/config/debug_sensing.rviz
@@ -625,6 +625,45 @@ Visualization Manager:
                 Reliability Policy: Reliable
                 Value: /localization/pose_twist_fusion_filter/pose
               Value: true
+            - Angle Tolerance: 0.10000000149011612
+              Class: rviz_default_plugins/Odometry
+              Covariance:
+                Orientation:
+                  Alpha: 0.5
+                  Color: 255; 255; 127
+                  Color Style: Unique
+                  Frame: Local
+                  Offset: 1
+                  Scale: 1
+                  Value: true
+                Position:
+                  Alpha: 0.30000001192092896
+                  Color: 204; 51; 204
+                  Scale: 1
+                  Value: true
+                Value: false
+              Enabled: true
+              Keep: 200
+              Name: Odometry
+              Position Tolerance: 0.10000000149011612
+              Shape:
+                Alpha: 1
+                Axes Length: 1
+                Axes Radius: 0.10000000149011612
+                Color: 255; 25; 0
+                Head Length: 0.30000001192092896
+                Head Radius: 0.10000000149011612
+                Shaft Length: 1
+                Shaft Radius: 0.05000000074505806
+                Value: Arrow
+              Topic:
+                Depth: 5
+                Durability Policy: Volatile
+                Filter size: 10
+                History Policy: Keep Last
+                Reliability Policy: Reliable
+                Value: /localization/kinematic_state
+              Value: true
           Enabled: true
           Name: EKF
       Enabled: true


### PR DESCRIPTION
追従性を確認しやすくするために、odometryを表示するようにしました（車両後ろの赤い線）。
![image](https://github.com/user-attachments/assets/5cb296c8-3285-4d43-a5d5-1918413e08ee)
