### PR TITLE
fix: fix aichallenge launch param according to the 9/11 experiment

### DIFF
--- a/aichallenge/workspace/src/aichallenge_launch/launch/aichallenge.launch.xml
+++ b/aichallenge/workspace/src/aichallenge_launch/launch/aichallenge.launch.xml
@@ -208,7 +208,7 @@
     <param name="use_external_target_vel" value="true"/>
     <param name="external_target_vel" value="2.77778"/>
     <param name="lookahead_gain" value="0.5"/>
-    <param name="lookahead_min_distance" value="4.0"/>
+    <param name="lookahead_min_distance" value="3.5"/>
     <param name="speed_proportional_gain" value="1.0"/>
     <param name="steering_tire_angle_gain" value="1.72"/>
 

--- a/aichallenge/workspace/src/aichallenge_launch/launch/aichallenge.launch.xml
+++ b/aichallenge/workspace/src/aichallenge_launch/launch/aichallenge.launch.xml
@@ -81,6 +81,7 @@
       <arg name="proc_stddev_vx_c" value="10.0"/>
       <arg name="proc_stddev_wz_c" value="5.0"/>
       <arg name="pose_additional_delay" value="0.5"/>
+      <arg name="extend_state_step" value="100"/>
     </include>
 
     <!-- twist2accel -->
@@ -204,12 +205,12 @@
   </group>
 
   <node pkg="simple_pure_pursuit" exec="simple_pure_pursuit" name="simple_pure_pursuit_node" output="screen">
-    <param name="use_external_target_vel" value="false"/>
-    <param name="external_target_vel" value="8.0"/>
+    <param name="use_external_target_vel" value="true"/>
+    <param name="external_target_vel" value="2.77778"/>
     <param name="lookahead_gain" value="0.5"/>
-    <param name="lookahead_min_distance" value="3.0"/>
+    <param name="lookahead_min_distance" value="4.0"/>
     <param name="speed_proportional_gain" value="1.0"/>
-    <param name="steering_tire_angle_gain" value="1.639"/>
+    <param name="steering_tire_angle_gain" value="1.72"/>
 
     <remap from="input/kinematics" to="/localization/kinematic_state"/>
     <remap from="input/trajectory" to="/planning/scenario_planning/trajectory"/>


### PR DESCRIPTION
9/11の実験でロックせずにコースを完走できたパラメータをデフォルトにします。
参考rosbagは2024-09-11-11-35-33です。

```
/localization/ekf_localizer:
  ros__parameters:
    enable_yaw_bias_estimation: false
    extend_state_step: 100
    pose_additional_delay: 0.5
    pose_frame_id: map
    pose_gate_dist: 10000.0
    pose_smoothing_steps: 1
    predict_frequency: 50.0
    proc_stddev_vx_c: 10.0
    proc_stddev_wz_c: 5.0
    proc_stddev_yaw_c: 0.005
    qos_overrides:
      /parameter_events:
        publisher:
          depth: 1000
          durability: volatile
          history: keep_last
          reliability: reliable
      /tf:
        publisher:
          depth: 100
          durability: volatile
          history: keep_last
          reliability: reliable
    show_debug_info: false
    tf_rate: 50.0
    twist_additional_delay: 0.0
    twist_gate_dist: 10000.0
    twist_smoothing_steps: 1
    use_sim_time: false

/simple_pure_pursuit_node:
  ros__parameters:
    external_target_vel: 2.77778
    lookahead_gain: 0.5
    lookahead_min_distance: 3.5
    qos_overrides:
      /parameter_events:
        publisher:
          depth: 1000
          durability: volatile
          history: keep_last
          reliability: reliable
    speed_proportional_gain: 1.0
    steering_tire_angle_gain: 1.0
    use_external_target_vel: true
    use_sim_time: false
    wheel_base: 1.087
```