### PR TITLE
feat: remove copy of imu_corrector param

### DIFF
--- a/aichallenge/workspace/src/aichallenge_submit/aichallenge_submit_launch/config/imu_corrector.param.yaml
+++ b/aichallenge/workspace/src/aichallenge_submit/aichallenge_submit_launch/config/imu_corrector.param.yaml
@@ -1,8 +1,0 @@
-/**:
-  ros__parameters:
-    angular_velocity_offset_x: 0.0    # [rad/s]
-    angular_velocity_offset_y: 0.0    # [rad/s]
-    angular_velocity_offset_z: -0.004  # [rad/s]
-    angular_velocity_stddev_xx: 0.03  # [rad/s]
-    angular_velocity_stddev_yy: 0.03  # [rad/s]
-    angular_velocity_stddev_zz: 0.03  # [rad/s]

--- a/aichallenge/workspace/src/aichallenge_submit/aichallenge_submit_launch/launch/reference.launch.xml
+++ b/aichallenge/workspace/src/aichallenge_submit/aichallenge_submit_launch/launch/reference.launch.xml
@@ -43,7 +43,7 @@
     </include>
     <group>
       <push-ros-namespace namespace="imu"/>
-      <arg name="imu_corrector_param_file" default="$(find-pkg-share aichallenge_submit_launch)/config/imu_corrector.param.yaml"/>
+      <arg name="imu_corrector_param_file" default="$(find-pkg-share imu_corrector)/config/imu_corrector.param.yaml"/>
       <include file="$(find-pkg-share imu_corrector)/launch/imu_corrector.launch.xml">
         <arg name="input_topic" value="imu_raw"/>
         <arg name="output_topic" value="imu_data"/>


### PR DESCRIPTION
imu_corrector.param が２つあり混乱しやすいので削除