### PR TITLE
fix: imu gnss poser build warning

### DIFF
--- a/aichallenge/workspace/src/aichallenge_submit/imu_gnss_poser/src/imu_gnss_poser_node.cpp
+++ b/aichallenge/workspace/src/aichallenge_submit/imu_gnss_poser/src/imu_gnss_poser_node.cpp
@@ -59,7 +59,7 @@ private:
         imu_msg_ = *msg;
     }
 
-    void twist_callback(const geometry_msgs::msg::TwistWithCovarianceStamped::SharedPtr msg)
+    void twist_callback(const geometry_msgs::msg::TwistWithCovarianceStamped::SharedPtr)
     {
         is_ekf_initialized_ = true;
     }


### PR DESCRIPTION
Fix this warning
```
/aichallenge/workspace/src/aichallenge_submit/imu_gnss_poser/src/imu_gnss_poser_node.cpp:62:89: warning: unused parameter ‘msg’ [-Wunused-parameter]
   62 |     void twist_callback(const geometry_msgs::msg::TwistWithCovarianceStamped::SharedPtr msg)
```