### PR TITLE
fix(racing_kart_sensor_kit_description): update awsim calibration file

### DIFF
--- a/aichallenge/workspace/src/aichallenge_submit/racing_kart_sensor_kit_description/config/awsim_sensor_kit_calibration.yaml
+++ b/aichallenge/workspace/src/aichallenge_submit/racing_kart_sensor_kit_description/config/awsim_sensor_kit_calibration.yaml
@@ -1,15 +1,15 @@
 sensor_kit_base_link:
   gnss_link:
-    x: 0.0
+    x: -0.26
     y: 0.0
     z: 0.0
     roll: 0.0
     pitch: 0.0
     yaw: 0.0
   imu_link:
-    x: 0.0
+    x: 0.85
     y: 0.0
     z: 0.0
     roll: 0.0
     pitch: 0.0
-    yaw: 0.0
+    yaw: -1.5707963268


### PR DESCRIPTION
- `racing_kart_sensor_kit_description`の`awsim_sensor_kit_calibration.yaml`を実機のセンサー設置位置を示す`sensor_kit_calibration.yaml`と合うように修正．
- 最新のAWSIMでもgnss_link, imu_linkを本PRに合うように修正．