### PR TITLE
fix: minor updates to fix run_evaluation.bash script

### DIFF
--- a/aichallenge/run_evaluation.bash
+++ b/aichallenge/run_evaluation.bash
@@ -44,6 +44,30 @@ wmctrl -a "AWSIM" && wmctrl -r "AWSIM" -e 0,0,0,900,1043
 ros2 service call /debug/service/capture_screen std_srvs/srv/Trigger >/dev/null
 sleep 1
 
+# Set initial pose
+echo "Set initial pose"
+ros2 topic pub -1 /initialpose geometry_msgs/msg/PoseWithCovarianceStamped "{ 
+  header: {
+    frame_id: 'map'
+  },
+  pose: {
+    pose: {
+      position: {
+        x: 89633.29,
+        y: 43127.57,
+        z: 0.0
+      },
+      orientation: {
+        x: 0.0,
+        y: 0.0,
+        z: 0.8778,
+        w: 0.4788
+      }
+    }
+  }
+}" >/dev/null
+sleep 1
+
 # Start driving and wait for the simulation to finish
 echo "Waiting for the simulation"
 ros2 service call /control/control_mode_request autoware_auto_vehicle_msgs/srv/ControlModeCommand '{mode: 1}' >/dev/null

--- a/aichallenge/workspace/src/aichallenge_system/aichallenge_system_launch/config/debug_sensing.rviz
+++ b/aichallenge/workspace/src/aichallenge_system/aichallenge_system_launch/config/debug_sensing.rviz
@@ -37,6 +37,8 @@ Panels:
     Splitter Ratio: 0.5
   - Class: tier4_localization_rviz_plugin/InitialPoseButtonPanel
     Name: InitialPoseButtonPanel
+  - Class: AutowareScreenCapturePanel
+    Name: AutowareScreenCapturePanel
 Visualization Manager:
   Class: ""
   Displays:
@@ -48,8 +50,6 @@ Visualization Manager:
           Frames:
             All Enabled: true
             base_link:
-              Value: true
-            gnss_base_link:
               Value: true
             gnss_link:
               Value: true
@@ -74,8 +74,6 @@ Visualization Manager:
                     {}
                   imu_link:
                     {}
-              gnss_base_link:
-                {}
               viewer:
                 {}
           Update Interval: 0
@@ -1927,8 +1925,8 @@ Visualization Manager:
       Scale: 41.36642837524414
       Target Frame: base_link
       Value: TopDownOrtho (rviz_default_plugins)
-      X: 4.791895866394043
-      Y: -8.544848442077637
+      X: 0
+      Y: 0
     Saved:
       - Class: rviz_default_plugins/ThirdPersonFollower
         Distance: 18
@@ -1966,6 +1964,8 @@ Visualization Manager:
         X: 0
         Y: 0
 Window Geometry:
+  AutowareScreenCapturePanel:
+    collapsed: false
   Displays:
     collapsed: false
   Height: 1074


### PR DESCRIPTION
- With the updated AWSIM version, the `run_evaluation.bash` was failing to run because the ScreenCapturePanel wasn't included in the Rviz2 config, and the initial pose of the vehicle had to be manually set.
- ScreenCapturePanel was included in the Rviz2 config.
- The initial pose was manually published in the `run_evaluation.bash` script.

## Checks
- `run_evaluation.bash` script was confirmed to run properly using both AWSIM_CPU and AWSIM_GPU.
- ![Screenshot from 2024-09-30 18-14-25](https://github.com/user-attachments/assets/1b8e2419-9e98-433b-932c-a332b681edf5)
