### PR TITLE
fix: add arguments to launch command

### DIFF
--- a/aichallenge/run_evaluation.bash
+++ b/aichallenge/run_evaluation.bash
@@ -21,7 +21,7 @@ sleep 20
 
 # Start Autoware
 echo "Start Autoware"
-ros2 launch aichallenge_system_launch aichallenge_system.launch.xml >autoware.log 2>&1 &
+ros2 launch aichallenge_system_launch aichallenge_system.launch.xml simulation:=true use_sim_time:=true run_rviz:=true >autoware.log 2>&1 &
 PID_AUTOWARE=$!
 sleep 10
 


### PR DESCRIPTION
launchファイルのデフォルトパラメータがなくなったので、パラメータをlaunchコマンドの引数で設定しました。
https://github.com/AutomotiveAIChallenge/aichallenge-2024/pull/122/files#diff-31934a03d3b77295435bf6f9facdf717d2f4fb9814ba48ea8096bcf4e593fcc9L11