### PR TITLE
fix: add default value to mode

### DIFF
--- a/aichallenge/run_autoware.bash
+++ b/aichallenge/run_autoware.bash
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-mode=${1}
+mode=${1:-vehicle}
 
 case "${mode}" in
 "awsim")


### PR DESCRIPTION
racing_kart_interfaceと同様に、modeのデフォルトをvehicleにしました。これによって、実験時にvehicleを入力する必要がなくなります。