### PR TITLE
fix: awsim brake map

### DIFF
--- a/aichallenge/workspace/src/aichallenge_system/aichallenge_awsim_adapter/launch/aichallenge_awsim_adapter.launch.xml
+++ b/aichallenge/workspace/src/aichallenge_system/aichallenge_awsim_adapter/launch/aichallenge_awsim_adapter.launch.xml
@@ -5,7 +5,7 @@
 
   <node pkg="aichallenge_awsim_adapter" exec="actuation_cmd_converter">
     <param name="csv_path_accel_map" value="$(var csv_path_accel_map)"/>
-    <param name="csv_path_brake_map" value="$(var csv_path_accel_map)"/>
+    <param name="csv_path_brake_map" value="$(var csv_path_brake_map)"/>
   </node>
   <node pkg="aichallenge_awsim_adapter" exec="sensor_converter">
     <param from="$(find-pkg-share aichallenge_awsim_adapter)/config/sensor_converter.param.yaml" />


### PR DESCRIPTION
[Slack](
https://jsae-aichallenge.slack.com/archives/C05CJ9BJ96Y/p1728138786253419?thread_ts=1728110430.451059&cid=C05CJ9BJ96Y)で共有いただいた通り、AWSIM変換時のパラメータ指定にミスが合ったため修正しました。