### PR TITLE
Revert "fix: change from copy to volume mount using rocker"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,9 @@ RUN apt-get -y install ros-humble-rqt-graph
 RUN apt install zenoh-bridge-ros2dds terminator -y
 RUN apt install arp-scan -y
 
+COPY --chmod=757 remote /remote 
+COPY --chmod=757 vehicle /vehicle
+
 # PATH="$PATH:/root/.local/bin"
 # PATH="/usr/local/cuda/bin:$PATH"
 ENV XDG_RUNTIME_DIR=/tmp/xdg

--- a/docker_run.sh
+++ b/docker_run.sh
@@ -8,7 +8,7 @@ case "${target}" in
     volume="output:/output"
     ;;
 "dev")
-    volume="output:/output aichallenge:/aichallenge remote:/remote vehicle:/vehicle"
+    volume="output:/output aichallenge:/aichallenge"
     ;;
 *)
     echo "invalid argument (use 'dev' or 'eval')"


### PR DESCRIPTION
Reverts AutomotiveAIChallenge/aichallenge-2024#158
vehicle/run_zenoh.bash でエラーが出るため戻します
```
Executing command: 
docker run --rm -it --device /dev/dri  -e ROS_DISTRO=humble --name zenoh  --network host  --privileged -v /home/tier4/aichallenge-2024/vehicle/aichallenge:/aichallenge  -e DISPLAY -e TERM   -e QT_X11_NO_MITSHM=1   -e XAUTHORITY=/tmp/.dockert5iwua2l.xauth -v /tmp/.dockert5iwua2l.xauth:/tmp/.dockert5iwua2l.xauth   -v /tmp/.X11-unix:/tmp/.X11-unix   -v /etc/localtime:/etc/localtime:ro  6c6a1be782dc zenoh-bridge-ros2dds -c /vehicle/zenoh.json5
2024-11-07T02:23:00.155410Z  INFO main ThreadId(01) zenoh_bridge_ros2dds: zenoh-bridge-ros2dds v1.0.1
thread 'main' panicked at zenoh-bridge-ros2dds/src/zenoh_args.rs:77:51:
called `Result::unwrap()` on an `Err` value: No such file or directory (os error 2) at /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/zenoh-config-1.0.1/src/lib.rs:804.
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```