### PR TITLE
chore: update bash titile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ COPY vehicle/cyclonedds.xml /opt/autoware/cyclonedds.xml
 
 FROM common AS dev
 
+RUN echo 'export PS1="\[\e]0;(AIC_DEV) ${debian_chroot:+($debian_chroot)}\u@\h: \w\a\](AIC_DEV) ${debian_chroot:+($debian_chroot)}\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ "' >> /etc/skel/.bashrc
 ENV RCUTILS_COLORIZED_OUTPUT=1
 
 FROM common AS eval


### PR DESCRIPTION
ホストかコンテナかをターミナルから判別しやすくするためのPRです。

・DEVコンテナを起動した際に、bashターミナル上部・プロンプト部に(AIC_DEV)が表示されるようにしました。

./docker_build.sh dev
 ./docker_run.sh dev gpu
で確認できます。

よろしくお願いします。