### PR TITLE
fix(evaluation): add graceful shutdown recursively

### DIFF
--- a/aichallenge/run_evaluation.bash
+++ b/aichallenge/run_evaluation.bash
@@ -54,7 +54,7 @@ graceful_shutdown() {
 
         # wait for the process to terminate
         local count=0
-        while kill -0 "$pid" 2>/dev/null && [ $count -lt $timeout ]; do
+        while kill -0 "$pid" 2>/dev/null && [ $count -lt $((timeout * 10)) ]; do
             sleep 0.1
             ((count++))
         done

--- a/aichallenge/run_evaluation.bash
+++ b/aichallenge/run_evaluation.bash
@@ -1,6 +1,134 @@
 #!/bin/bash
 AWSIM_DIRECTORY="/aichallenge/simulator/AWSIM"
 
+# Create a temporary file to store process IDs
+PID_FILE=$(mktemp)
+echo "Process ID file: $PID_FILE"
+
+# recursively get child processes
+get_child_pids() {
+    local parent_pid=$1
+    local child_pids
+
+    child_pids=$(pgrep -P "$parent_pid")
+    for pid in $child_pids; do
+        echo "$pid" >>"$PID_FILE"
+        get_child_pids "$pid"
+    done
+}
+
+# update process list
+update_process_list() {
+    local main_pids=("$PID_AWSIM" "$PID_AUTOWARE" "$PID_ROSBAG")
+
+    # clear the PID file
+    >"$PID_FILE"
+
+    # record main process PIDs
+    for pid in "${main_pids[@]}"; do
+        if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
+            echo "$pid" >>"$PID_FILE"
+            get_child_pids "$pid"
+        fi
+    done
+
+    # get child processes of main processes
+    for pattern in "ros2" "autoware" "web_server" "rviz"; do
+        pgrep -f "$pattern" | while read -r pid; do
+            # check if the PID is already in the file
+            if ! grep -q "^$pid$" "$PID_FILE"; then
+                echo "$pid" >>"$PID_FILE"
+            fi
+        done
+    done
+}
+
+# shutdown function
+graceful_shutdown() {
+    local pid=$1
+    local timeout=${2:-30} # timeout in seconds, default is 30 seconds
+
+    if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
+        echo "Sending SIGTERM to PID $pid"
+        kill "$pid"
+
+        # wait for the process to terminate
+        local count=0
+        while kill -0 "$pid" 2>/dev/null && [ $count -lt $timeout ]; do
+            sleep 0.1
+            ((count++))
+        done
+
+        # if the process is still running after timeout, force kill
+        if kill -0 "$pid" 2>/dev/null; then
+            echo "Process $pid did not terminate gracefully after $timeout seconds, forcing kill"
+            kill -9 "$pid"
+            sleep 0.1
+        fi
+    fi
+}
+
+# Function to handle Ctrl+C and normal termination
+cleanup() {
+    echo "Termination signal received. Cleaning up..."
+
+    # get the latest process list
+    update_process_list
+
+    # Stop recording rosbag
+    echo "Stop rosbag"
+    if [[ -n "$PID_ROSBAG" ]] && kill -0 "$PID_ROSBAG" 2>/dev/null; then
+        graceful_shutdown "$PID_ROSBAG" 15
+    fi
+
+    # shutdown ROS2 nodes
+    echo "Shutting down ROS2 nodes gracefully..."
+    ros2 node list 2>/dev/null | while read -r node; do
+        echo "Shutting down node: $node"
+        ros2 lifecycle set "$node" shutdown 2>/dev/null || true
+        ros2 node kill "$node" 2>/dev/null || true
+    done
+    sleep 1
+
+    # Stop Autoware
+    echo "Stop Autoware"
+    if [[ -n "$PID_AUTOWARE" ]] && kill -0 "$PID_AUTOWARE" 2>/dev/null; then
+        graceful_shutdown "$PID_AUTOWARE" 20
+    fi
+
+    # Stop AWSIM
+    echo "Stop AWSIM"
+    if [[ -n "$PID_AWSIM" ]] && kill -0 "$PID_AWSIM" 2>/dev/null; then
+        graceful_shutdown "$PID_AWSIM" 10
+    fi
+
+    # Compress rosbag
+    echo "Compress rosbag"
+    if [ -d "rosbag2_autoware" ]; then
+        tar -czf rosbag2_autoware.tar.gz rosbag2_autoware
+        rm -rf rosbag2_autoware
+    fi
+
+    # check for remaining processes
+    echo "Checking for remaining processes..."
+    if [[ -f "$PID_FILE" ]]; then
+        while read -r pid; do
+            if kill -0 "$pid" 2>/dev/null; then
+                echo "Attempting graceful shutdown of remaining PID $pid"
+                graceful_shutdown "$pid" 30
+            fi
+        done <"$PID_FILE"
+        rm "$PID_FILE"
+    fi
+
+    echo "Cleanup complete."
+    # Stop ros2 daemon
+    ros2 daemon stop
+    exit 0
+}
+# Trap Ctrl+C (SIGINT) and normal termination (EXIT)
+trap cleanup SIGINT SIGTERM EXIT
+
 # Move working directory
 OUTPUT_DIRECTORY=$(date +%Y%m%d-%H%M%S)
 cd /output || exit
@@ -13,25 +141,52 @@ source /aichallenge/workspace/install/setup.bash
 sudo ip link set multicast on lo
 sudo sysctl -w net.core.rmem_max=2147483647 >/dev/null
 
-# Start AWSIM
+# Start AWSIM with nohup
 echo "Start AWSIM"
-$AWSIM_DIRECTORY/AWSIM.x86_64 >/dev/null &
+nohup $AWSIM_DIRECTORY/AWSIM.x86_64 >/dev/null &
 PID_AWSIM=$!
 echo "AWSIM PID: $PID_AWSIM"
-sleep 20
+echo "$PID_AWSIM" >"$PID_FILE"
+# recursively get child processes
+get_child_pids "$PID_AWSIM"
+sleep 3
 
-# Start Autoware
+# Start Autoware with nohup
 echo "Start Autoware"
-ros2 launch aichallenge_system_launch aichallenge_system.launch.xml simulation:=true use_sim_time:=true run_rviz:=true >autoware.log 2>&1 &
+nohup ros2 launch aichallenge_system_launch aichallenge_system.launch.xml simulation:=true use_sim_time:=true run_rviz:=true >autoware.log 2>&1 &
 PID_AUTOWARE=$!
 echo "Autoware PID: $PID_AUTOWARE"
-sleep 10
+echo "$PID_AUTOWARE" >>"$PID_FILE"
+# recursively get child processes
+get_child_pids "$PID_AUTOWARE"
+sleep 3
 
-# Start recording rosbag
+# Start recording rosbag with nohup
 echo "Start rosbag"
-ros2 bag record -a -o rosbag2_autoware >/dev/null 2>&1 &
+nohup ros2 bag record -a -o rosbag2_autoware >/dev/null 2>&1 &
 PID_ROSBAG=$!
+echo "ROS Bag PID: $PID_ROSBAG"
+echo "$PID_ROSBAG" >>"$PID_FILE"
+# recursively get child processes
+get_child_pids "$PID_ROSBAG"
 sleep 5
+
+# run updater
+(
+    while true; do
+        sleep 5
+
+        # update if the main process is still running
+        if [[ -n "$PID_AWSIM" ]] && kill -0 "$PID_AWSIM" 2>/dev/null; then
+            update_process_list
+        else
+            # if the main process is not running, exit the loop
+            break
+        fi
+    done
+) &
+PID_UPDATER=$!
+echo "$PID_UPDATER" >>"$PID_FILE"
 
 # Start recording rviz2
 echo "Start screen capture"
@@ -43,29 +198,19 @@ done
 wmctrl -a "RViz" && wmctrl -r "RViz" -e 0,0,0,1920,1043
 wmctrl -a "AWSIM" && wmctrl -r "AWSIM" -e 0,0,0,900,1043
 
-bash /aichallenge/publish.sh all
+bash /aichallenge/publish.bash all
+
+# Wait for AWSIM to finish (this is the main process we're waiting for)
 wait "$PID_AWSIM"
 
 # Stop recording rviz2
 echo "Stop screen capture"
-bash /aichallenge/publish.sh screen
+bash /aichallenge/publish.bash screen
 sleep 10
-
-# Stop recording rosbag
-echo "Stop rosbag"
-kill "$PID_ROSBAG"
-wait "$PID_ROSBAG"
-
-# Stop Autoware
-echo "Stop Autoware"
-kill "$PID_AUTOWARE"
-wait "$PID_AUTOWARE"
 
 # Convert result
 echo "Convert result"
 python3 /aichallenge/workspace/src/aichallenge_system/script/result-converter.py 60 11
 
-# Compress rosbag
-echo "Compress rosbag"
-tar -czf rosbag2_autoware.tar.gz rosbag2_autoware
-rm -rf rosbag2_autoware
+# If AWSIM finished naturally, we'll proceed with the rest of the cleanup
+cleanup


### PR DESCRIPTION
run evaluationがcontrol +Cで死なない問題の修正PRをいれました。
下記の条件でテストしています。
1. AWSIMをGUI上で途中で閉じる。
2. 実行中にteminalでCTRL+Cを押して終了する

結果のターミナルログは下記になります。
```
bash run_evaluation.bash 
Process ID file: /tmp/tmp.S4gvLnSY0G
Start AWSIM
AWSIM PID: 13723
nohup: redirecting stderr to stdout
Start Autoware
Autoware PID: 13780
Start rosbag
ROS Bag PID: 14317
Start screen capture
Capturing screen...
Screen capture requested
Setting initial pose...
Initial pose set successfully
Requesting control mode change...
Control mode change requested
^CTermination signal received. Cleaning up...
Stop rosbag
Sending SIGTERM to PID 14317
Shutting down ROS2 nodes gracefully...
Shutting down node: /default_ad_api/web_server
Shutting down node: /launch_ros_13780
Stop Autoware
Sending SIGTERM to PID 13780
Stop AWSIM
Compress rosbag
Checking for remaining processes...
Attempting graceful shutdown of remaining PID 13835
Sending SIGTERM to PID 13835
Cleanup complete.
The daemon has been stopped
Termination signal received. Cleaning up...
Stop rosbag
Shutting down ROS2 nodes gracefully...
Stop Autoware
Stop AWSIM
Compress rosbag
Checking for remaining processes...
Cleanup complete.
The daemon has been stopped
```