### PR TITLE
feat: new logs

### DIFF
--- a/docker_build.sh
+++ b/docker_build.sh
@@ -15,8 +15,9 @@ case "${target}" in
     ;;
 esac
 
-LOG_FILE="output/latest/docker_build.log"
-touch $LOG_FILE
+LOG_DIR="output/latest"
+mkdir -p $LOG_DIR
+LOG_FILE="$LOG_DIR/docker_build.log"
 echo "A build log is stored at : file://$LOG_FILE"
 
 # shellcheck disable=SC2086

--- a/docker_build.sh
+++ b/docker_build.sh
@@ -15,7 +15,12 @@ case "${target}" in
     ;;
 esac
 
-sudo modprobe msr
-sudo setfacl -m u:"$(whoami)":r /dev/cpu/*/msr
+LOG_FILE="output/latest/docker_build.log"
+touch $LOG_FILE
+echo "A build log is stored at : file://$LOG_FILE"
+
 # shellcheck disable=SC2086
-docker build ${opts} --target "${target}" -t "aichallenge-2024-${target}-${USER}" .
+docker build ${opts} --progress=plain --target "${target}" -t "aichallenge-2024-${target}-${USER}" .  2>&1 | tee "$LOG_FILE"
+echo "========================================================"
+echo "This log is in : file://$LOG_FILE"
+echo "========================================================"

--- a/docker_build.sh
+++ b/docker_build.sh
@@ -15,6 +15,9 @@ case "${target}" in
     ;;
 esac
 
+sudo modprobe msr
+sudo setfacl -m u:"$(whoami)":r /dev/cpu/*/msr
+
 LOG_DIR="output/latest"
 mkdir -p $LOG_DIR
 LOG_FILE="$LOG_DIR/docker_build.log"

--- a/docker_build.sh
+++ b/docker_build.sh
@@ -24,7 +24,7 @@ LOG_FILE="$LOG_DIR/docker_build.log"
 echo "A build log is stored at : file://$LOG_FILE"
 
 # shellcheck disable=SC2086
-docker build ${opts} --progress=plain --target "${target}" -t "aichallenge-2024-${target}-${USER}" .  2>&1 | tee "$LOG_FILE"
+docker build ${opts} --progress=plain --target "${target}" -t "aichallenge-2024-${target}-${USER}" . 2>&1 | tee "$LOG_FILE"
 echo "========================================================"
 echo "This log is in : file://$LOG_FILE"
 echo "========================================================"

--- a/docker_run.sh
+++ b/docker_run.sh
@@ -31,5 +31,9 @@ fi
 
 mkdir -p output
 
+LOG_FILE="output/latest/docker_run.log"
+touch $LOG_FILE
+echo "A rocker run log is stored at : file://$LOG_FILE"
+
 # shellcheck disable=SC2086
-rocker ${opts} --x11 --devices /dev/dri --user --net host --privileged --name "aichallenge-2024-$(date "+%Y-%m-%d-%H-%M-%S")" --volume ${volume} -- "aichallenge-2024-${target}-${USER}"
+rocker ${opts} --x11 --devices /dev/dri --user --net host --privileged --name "aichallenge-2024-$(date "+%Y-%m-%d-%H-%M-%S")" --volume ${volume} -- "aichallenge-2024-${target}-${USER}" 2>&1 | tee "$LOG_FILE"

--- a/docker_run.sh
+++ b/docker_run.sh
@@ -31,8 +31,9 @@ fi
 
 mkdir -p output
 
-LOG_FILE="output/latest/docker_run.log"
-touch $LOG_FILE
+LOG_DIR="output/latest"
+mkdir -p $LOG_DIR
+LOG_FILE="$LOG_DIR/docker_run.log"
 echo "A rocker run log is stored at : file://$LOG_FILE"
 
 # shellcheck disable=SC2086

--- a/vehicle/run_zenoh.bash
+++ b/vehicle/run_zenoh.bash
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # shellcheck disable=SC2086
-rocker --x11 --devices /dev/dri --env ROS_DISTRO=humble --user --net host --privileged --name zenoh --volume aichallenge:/aichallenge -- "aichallenge-2024-dev-${USER}" zenoh-bridge-ros2dds -c /vehicle/zenoh.json5
+rocker --x11 --devices /dev/dri --env ROS_DISTRO=humble --user --net host --privileged --name zenoh --volume aichallenge:/aichallenge vehicle:/vehicle -- "aichallenge-2024-dev-${USER}" zenoh-bridge-ros2dds -c /vehicle/zenoh.json5

--- a/vehicle/zenoh.json5
+++ b/vehicle/zenoh.json5
@@ -55,8 +55,8 @@
       allow: {
         publishers: [".*"],
         subscribers: ["/racing_kart/joy", "/initialpose"],
-        service_servers: [],
-        service_clients: [],
+        service_servers: [".*"],
+        service_clients: [".*"],
         action_servers: [],
         action_clients: [],
       },


### PR DESCRIPTION
```
#0 building with "default" instance using docker driver

#1 [internal] load build definition from Dockerfile
#1 transferring dockerfile: 2.02kB done
#1 DONE 0.0s

#2 [internal] load metadata for ghcr.io/automotiveaichallenge/autoware-universe:humble-latest
#2 DONE 0.0s

#3 [internal] load .dockerignore
#3 transferring context: 2B done
#3 DONE 0.0s

#4 [common  1/10] FROM ghcr.io/automotiveaichallenge/autoware-universe:humble-latest
#4 CACHED

#5 [internal] load build context
#5 transferring context: 71B 0.3s done
#5 DONE 0.3s

#6 [common  2/10] RUN echo "deb [trusted=yes] https://download.eclipse.org/zenoh/debian-repo/ /" | tee -a /etc/apt/sources.list > /dev/null && apt-get update
#6 0.627 Get:1 http://security.ubuntu.com/ubuntu jammy-security InRelease [129 kB]
#6 0.663 Get:2 http://packages.ros.org/ros2/ubuntu jammy InRelease [4682 B]
#6 0.750 Get:3 http://archive.ubuntu.com/ubuntu jammy InRelease [270 kB]
#6 0.905 Get:4 http://packages.ros.org/ros2/ubuntu jammy/main amd64 Packages [1665 kB]
```